### PR TITLE
chore: add agent card discovery endpoints

### DIFF
--- a/samples/dotnet/A2A-CustomerService/backend/Program.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Program.cs
@@ -86,16 +86,16 @@ app.MapGet("/api/a2a/agents", () =>
 });
 
 // Add well-known Agent Card endpoints for discovery
-app.MapGet("/frontdesk/.well-known/agent.json", () =>
+app.MapGet("/frontdesk/.well-known/agent-card.json", () =>
     Results.Ok(AgentCardFactory.CreateFrontDeskCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/frontdesk")));
 
-app.MapGet("/billing/.well-known/agent.json", () =>
+app.MapGet("/billing/.well-known/agent-card.json", () =>
     Results.Ok(AgentCardFactory.CreateBillingCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/billing")));
 
-app.MapGet("/technical/.well-known/agent.json", () =>
+app.MapGet("/technical/.well-known/agent-card.json", () =>
     Results.Ok(AgentCardFactory.CreateTechnicalCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/technical")));
 
-app.MapGet("/orchestrator/.well-known/agent.json", () =>
+app.MapGet("/orchestrator/.well-known/agent-card.json", () =>
     Results.Ok(AgentCardFactory.CreateOrchestratorCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/orchestrator")));
 
 // Add a simple health check endpoint

--- a/samples/dotnet/A2A-CustomerService/backend/README.md
+++ b/samples/dotnet/A2A-CustomerService/backend/README.md
@@ -9,16 +9,43 @@ AOI_ENDPOINT_SWDN=https://your-openai-resource.openai.azure.com/
 AOI_KEY_SWDN=your-api-key-here
 ```
 
+## A2A Protocol 0.3.0 Compliance
+
+This application is fully compliant with **A2A Protocol version 0.3.0**. Key compliance features:
+
+### Agent Discovery Endpoints
+
+- `/frontdesk/.well-known/agent-card.json` - Front Desk Agent Card
+- `/billing/.well-known/agent-card.json` - Billing Agent Card
+- `/technical/.well-known/agent-card.json` - Technical Agent Card
+- `/orchestrator/.well-known/agent-card.json` - Orchestrator Agent Card
+
+### Transport Support
+
+- **JSON-RPC 2.0**: Native A2A protocol support
+- **HTTP REST**: Standard HTTP API compatibility
+- **Dual Transport**: Each agent supports both transport methods
+
+### Protocol Features
+
+- ✅ Protocol version 0.3.0 in Agent Cards
+- ✅ Well-known endpoint discovery with `agent-card.json` (0.3.0 breaking change)
+- ✅ Dual transport announcement (`preferredTransport`)
+- ✅ Comprehensive skill definitions with input/output schemas
+- ✅ Provider information and documentation URLs
+- ✅ Agent capabilities and interface declarations
+
 ## Runtime Toggle
 
 Switch between mock and real implementations:
+
 - **Frontend**: Use the toggle switch in the "Implementation Mode" card
 - **API**: `POST /api/customerservice/toggle-implementation`
 
 ## Configuration Priority
 
 1. Runtime toggle (highest)
-2. Environment variables  
+2. Environment variables
 3. appsettings.json (fallback)
 
 Perfect for .NET! 🚀


### PR DESCRIPTION
Add agent card discovery endpoints and update README

Introduce new endpoints for agent card discovery in `Program.cs`, replacing previous agent JSON endpoints. Each endpoint returns an agent card created by `AgentCardFactory`. Update `README.md` to reflect A2A Protocol version 0.3.0 compliance and clarify configuration priority.