### PR TITLE
Add A2A transport client and refactor agent communication

### DIFF
--- a/samples/dotnet/A2A-CustomerService/backend/Configuration/ServiceConfiguration.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Configuration/ServiceConfiguration.cs
@@ -53,6 +53,12 @@ public static class ServiceConfiguration
         services.AddSingleton<TechnicalAgent>();
         services.AddSingleton<OrchestratorAgent>();
 
+        // A2A transport client
+        services.AddHttpClient<IA2ATransportClient, A2ATransportClient>(client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(15);
+        });
+
         return services;
     }
 }

--- a/samples/dotnet/A2A-CustomerService/backend/Models/AgentResponse.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Models/AgentResponse.cs
@@ -8,7 +8,7 @@ public class AgentResponse
     public DateTime Timestamp { get; set; } = DateTime.UtcNow;
     public ResponseStatus Status { get; set; } = ResponseStatus.Pending;
     public Dictionary<string, object> Metadata { get; set; } = new();
-    public A2A.Message ToMessage(string contextId = null)
+    public A2A.Message ToMessage(string? contextId = null)
     {
         // Use provided contextId (e.g., ticket/workflow/correlation ID) if available, else fallback to AgentId
         var metadata = new Dictionary<string, System.Text.Json.JsonElement>

--- a/samples/dotnet/A2A-CustomerService/backend/Models/ApiModels.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Models/ApiModels.cs
@@ -30,14 +30,6 @@ public class SubmitTicketRequest
     public string Category { get; set; } = "general";
 }
 
-public class ProcessingUpdate
-{
-    public string TicketId { get; set; } = string.Empty;
-    public string UpdateType { get; set; } = string.Empty;
-    public object Data { get; set; } = new();
-    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
-}
-
 public class ToggleImplementationRequest
 {
     public bool UseReal { get; set; }

--- a/samples/dotnet/A2A-CustomerService/backend/Program.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Program.cs
@@ -49,10 +49,6 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-
-
-
-
 var frontDeskAgent = app.Services.GetRequiredService<FrontDeskAgent>();
 var billingAgent = app.Services.GetRequiredService<BillingAgent>();
 var technicalAgent = app.Services.GetRequiredService<TechnicalAgent>();
@@ -87,16 +83,16 @@ app.MapGet("/api/a2a/agents", () =>
 
 // Add well-known Agent Card endpoints for discovery
 app.MapGet("/frontdesk/.well-known/agent-card.json", () =>
-    Results.Ok(AgentCardFactory.CreateFrontDeskCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/frontdesk")));
+    Results.Ok(AgentCardFactory.CreateFrontDeskCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:5000"}/frontdesk")));
 
 app.MapGet("/billing/.well-known/agent-card.json", () =>
-    Results.Ok(AgentCardFactory.CreateBillingCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/billing")));
+    Results.Ok(AgentCardFactory.CreateBillingCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:5000"}/billing")));
 
 app.MapGet("/technical/.well-known/agent-card.json", () =>
-    Results.Ok(AgentCardFactory.CreateTechnicalCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/technical")));
+    Results.Ok(AgentCardFactory.CreateTechnicalCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:5000"}/technical")));
 
 app.MapGet("/orchestrator/.well-known/agent-card.json", () =>
-    Results.Ok(AgentCardFactory.CreateOrchestratorCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:7041"}/orchestrator")));
+    Results.Ok(AgentCardFactory.CreateOrchestratorCard($"{app.Configuration["A2A:BaseUrl"] ?? "https://localhost:5000"}/orchestrator")));
 
 // Add a simple health check endpoint
 app.MapGet("/health", () => new { status = "healthy", timestamp = DateTime.UtcNow });

--- a/samples/dotnet/A2A-CustomerService/backend/Services/A2ATransportClient.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Services/A2ATransportClient.cs
@@ -1,0 +1,84 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using A2A;
+
+namespace A2ACustomerService.Services;
+
+public interface IA2ATransportClient
+{
+    Task<Message> SendMessageAsync(string agentPath, Message message, CancellationToken cancellationToken = default);
+}
+
+internal sealed class A2ATransportClient : IA2ATransportClient
+{
+    private readonly HttpClient _http;
+    private readonly string _baseUrl;
+    private readonly JsonSerializerOptions _json;
+
+    private const string JsonRpcVersion = "2.0";
+    private const string MethodMessageSend = "message/send"; // per A2A JSON-RPC
+
+    public A2ATransportClient(HttpClient httpClient, IConfiguration configuration)
+    {
+        _http = httpClient;
+        _baseUrl = configuration["A2A:BaseUrl"]?.TrimEnd('/') ?? "http://localhost:5000";
+        _json = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+    }
+
+    public async Task<Message> SendMessageAsync(string agentPath, Message message, CancellationToken cancellationToken = default)
+    {
+        var url = _baseUrl + agentPath; // e.g., http://localhost:5000/billing
+
+        var req = new JsonRpcRequest
+        {
+            Id = Guid.NewGuid().ToString(),
+            Method = MethodMessageSend,
+            Params = new MessageSendParamsWrapper { Message = message }
+        };
+
+        using var response = await _http.PostAsJsonAsync(url, req, _json, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var rpc = await response.Content.ReadFromJsonAsync<JsonRpcResponse<Message>>(_json, cancellationToken)
+                  ?? throw new InvalidOperationException("Empty JSON-RPC response.");
+
+        if (rpc.Error != null)
+        {
+            throw new InvalidOperationException($"A2A JSON-RPC error: {rpc.Error.Code} {rpc.Error.Message}");
+        }
+
+        return rpc.Result ?? throw new InvalidOperationException("A2A response missing result message.");
+    }
+
+    private sealed class JsonRpcRequest
+    {
+        public string Jsonrpc { get; set; } = JsonRpcVersion;
+        public string Id { get; set; } = string.Empty;
+        public string Method { get; set; } = MethodMessageSend;
+        public object? Params { get; set; }
+    }
+
+    private sealed class JsonRpcError
+    {
+        public int Code { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public object? Data { get; set; }
+    }
+
+    private sealed class JsonRpcResponse<TResult>
+    {
+        public string Jsonrpc { get; set; } = JsonRpcVersion;
+        public string? Id { get; set; }
+        public TResult? Result { get; set; }
+        public JsonRpcError? Error { get; set; }
+    }
+
+    private sealed class MessageSendParamsWrapper
+    {
+        public Message? Message { get; set; }
+    }
+}

--- a/samples/dotnet/A2A-CustomerService/backend/Services/Agents/A2AAgents.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Services/Agents/A2AAgents.cs
@@ -103,7 +103,7 @@ Keep your response to 1-2 sentences maximum. Simply acknowledge and confirm rout
                     return BaseA2AAgent.CreateErrorMessage($"Error processing request: {ex.Message}", messageSendParams?.Message?.ContextId);
                 }
             };
-            taskManager.OnAgentCardQuery = async (agentUrl, ct) => AgentCardFactory.CreateFrontDeskCard(agentUrl);
+            taskManager.OnAgentCardQuery = (agentUrl, ct) => Task.FromResult(AgentCardFactory.CreateFrontDeskCard(agentUrl));
         }
     }
 
@@ -148,7 +148,7 @@ Focus on being clear about financial matters and resolving billing issues.
                     return BaseA2AAgent.CreateErrorMessage($"Error processing request: {ex.Message}", messageSendParams?.Message?.ContextId);
                 }
             };
-            taskManager.OnAgentCardQuery = async (agentUrl, ct) => AgentCardFactory.CreateBillingCard(agentUrl);
+            taskManager.OnAgentCardQuery = (agentUrl, ct) => Task.FromResult(AgentCardFactory.CreateBillingCard(agentUrl));
         }
     }
 
@@ -193,7 +193,7 @@ Focus on being thorough and providing clear technical solutions.
                     return BaseA2AAgent.CreateErrorMessage($"Error processing request: {ex.Message}", messageSendParams?.Message?.ContextId);
                 }
             };
-            taskManager.OnAgentCardQuery = async (agentUrl, ct) => AgentCardFactory.CreateTechnicalCard(agentUrl);
+            taskManager.OnAgentCardQuery = (agentUrl, ct) => Task.FromResult(AgentCardFactory.CreateTechnicalCard(agentUrl));
         }
     }
 
@@ -204,7 +204,7 @@ Focus on being thorough and providing clear technical solutions.
         {
         }
 
-        public override async Task<AgentResponse> ProcessTicketAsync(CustomerTicket ticket)
+        public override Task<AgentResponse> ProcessTicketAsync(CustomerTicket ticket)
         {
             // This method won't be used for the orchestrator as it handles multiple responses
             throw new NotImplementedException("Use SynthesizeResponsesAsync for orchestrator agent");
@@ -272,19 +272,20 @@ Create the final response that will be sent to the customer.
 
         public void Attach(ITaskManager taskManager)
         {
-            taskManager.OnMessageReceived = async (messageSendParams, ct) =>
+            taskManager.OnMessageReceived = (messageSendParams, ct) =>
             {
                 try
                 {
                     // Orchestrator agent expects a list of specialist responses, so this is a placeholder
-                    return new Message { Role = MessageRole.Agent, Parts = new List<Part> { new TextPart { Text = "Orchestrator response not implemented." } } };
+                    var msg = new Message { Role = MessageRole.Agent, Parts = new List<Part> { new TextPart { Text = "Orchestrator response not implemented." } } };
+                    return Task.FromResult(msg);
                 }
                 catch (Exception ex)
                 {
-                    return BaseA2AAgent.CreateErrorMessage($"Error processing request: {ex.Message}", messageSendParams?.Message?.ContextId);
+                    return Task.FromResult(BaseA2AAgent.CreateErrorMessage($"Error processing request: {ex.Message}", messageSendParams?.Message?.ContextId));
                 }
             };
-            taskManager.OnAgentCardQuery = async (agentUrl, ct) => AgentCardFactory.CreateOrchestratorCard(agentUrl);
+            taskManager.OnAgentCardQuery = (agentUrl, ct) => Task.FromResult(AgentCardFactory.CreateOrchestratorCard(agentUrl));
         }
     }
 }

--- a/samples/dotnet/A2A-CustomerService/backend/Services/LLMService.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Services/LLMService.cs
@@ -27,19 +27,4 @@ public class LLMService : ILLMService
             return "I apologize, but I'm unable to process your request at the moment. Please try again later.";
         }
     }
-
-    public async Task<string> AnalyzeTicketAsync(string subject, string description)
-    {
-        var prompt = $@"
-Analyze this customer service ticket and provide a brief professional response:
-
-Subject: {subject}
-Description: {description}
-
-Provide a helpful, empathetic response that addresses the customer's concern.
-Keep the response concise and professional.
-";
-
-        return await GenerateTextAsync(prompt, CancellationToken.None);
-    }
 }

--- a/samples/dotnet/A2A-CustomerService/backend/Services/MockTicketService.cs
+++ b/samples/dotnet/A2A-CustomerService/backend/Services/MockTicketService.cs
@@ -64,7 +64,7 @@ public class MockTicketService : ITicketService
         };
     }
 
-    public async Task<CustomerTicket> SubmitTicketAsync(SubmitTicketRequest request)
+    public Task<CustomerTicket> SubmitTicketAsync(SubmitTicketRequest request)
     {
         var ticket = new CustomerTicket
         {
@@ -84,7 +84,7 @@ public class MockTicketService : ITicketService
         // Start processing asynchronously
         _ = Task.Run(() => ProcessTicketAsync(ticket.Id));
 
-        return ticket;
+        return Task.FromResult(ticket);
     }
 
     private TicketPriority DeterminePriority(string subject, string description)

--- a/samples/dotnet/A2A-CustomerService/frontend/src/components/ImplementationToggle.tsx
+++ b/samples/dotnet/A2A-CustomerService/frontend/src/components/ImplementationToggle.tsx
@@ -14,6 +14,7 @@ export function ImplementationToggle({ onImplementationChange }: ImplementationT
   const [isLoading, setIsLoading] = useState(true);
   const [isToggling, setIsToggling] = useState(false);
   const [isHealthy, setIsHealthy] = useState(false);
+  const [transport, setTransport] = useState<string | null>(null);
 
   const checkStatus = async () => {
     try {
@@ -26,6 +27,18 @@ export function ImplementationToggle({ onImplementationChange }: ImplementationT
       // Get implementation status
       const statusResponse = await customerServiceAPI.getStatus();
       setStatus(statusResponse);
+      // Probe preferred transport from frontdesk agent-card
+      try {
+        const res = await fetch('http://localhost:5000/frontdesk/.well-known/agent-card.json');
+        if (res.ok) {
+          const card = await res.json();
+          setTransport(card?.preferredTransport ?? null);
+        } else {
+          setTransport(null);
+        }
+      } catch {
+        setTransport(null);
+      }
       
       // Notify parent component
       onImplementationChange?.(statusResponse.implementation === 'real');
@@ -33,6 +46,7 @@ export function ImplementationToggle({ onImplementationChange }: ImplementationT
       console.error('Failed to check status:', error);
       setIsHealthy(false);
       setStatus(null);
+      setTransport(null);
     } finally {
       setIsLoading(false);
     }
@@ -126,6 +140,11 @@ export function ImplementationToggle({ onImplementationChange }: ImplementationT
                     </div>
                   )}
                 </Badge>
+                {transport && (
+                  <Badge variant="outline" title="Preferred Transport">
+                    Transport: {transport}
+                  </Badge>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
- Introduced an A2A transport client for HTTP communication with agents.
- Updated `ToMessage` method in `AgentResponse` to accept a nullable `contextId`.
- Removed the `ProcessingUpdate` class from `ApiModels.cs`.
- Changed agent card endpoint base URL from `localhost:7041` to `localhost:5000`.
- Refactored `A2ATicketService` to utilize `IA2ATransportClient`, enhancing modularity.
- Simplified asynchronous task handling by using `Task.FromResult` where applicable.
- Added a new `A2ATransportClient` class for JSON-RPC communication with agents.
- Improved frontend integration with agent discovery and transport details.
- Enhanced `ImplementationToggle` to probe preferred transport from the front desk agent card.