### PR TITLE
feat: Add MAF Skill Incident Command Center sample

### DIFF
--- a/samples/dotnet/maf-skill-incident-command-center/.gitignore
+++ b/samples/dotnet/maf-skill-incident-command-center/.gitignore
@@ -1,0 +1,6 @@
+**/bin/
+**/obj/
+frontend/node_modules/
+frontend/dist/
+frontend/package-lock.json
+frontend/tsconfig.tsbuildinfo

--- a/samples/dotnet/maf-skill-incident-command-center/README.md
+++ b/samples/dotnet/maf-skill-incident-command-center/README.md
@@ -12,6 +12,7 @@ Scenario: **Supply Chain Disruption Triage** with a phased capability model:
 - Backend: ASP.NET Core (`net10.0`), Microsoft Agent Framework, Azure OpenAI
 - Frontend: React + Vite + TypeScript
 - Skills: file-based skill packages loaded via `FileAgentSkillsProvider`
+- Native skill invocation: context provider exposes `load_skill` and `read_skill_resource` tools to the agent
 
 ## Project Layout
 
@@ -65,6 +66,27 @@ POST /api/communications/draft
 GET  /api/skills
 GET  /api/runs/{runId}/events
 ```
+
+## Native Skills Integration
+
+This sample uses native Agent Framework skill invocation semantics:
+
+1. Skills are advertised to the model through an `AIContextProvider`.
+2. The provider adds native skill tools for the current run:
+   - `load_skill(skillName)`
+   - `read_skill_resource(skillName, resourcePath)`
+3. The model invokes these tools on demand, and the backend records timeline events.
+
+## Terminal Verbosity
+
+Backend logging is configured for detailed flow tracing. While running `dotnet run`, you will see:
+
+- HTTP request start/completion with latency.
+- Session and run lifecycle logs (`sessionId`, `runId`).
+- Native tool calls:
+  - `load_skill`
+  - `read_skill_resource`
+- Guard logs when required native skill invocation is missing.
 
 ## Environment Variables
 

--- a/samples/dotnet/maf-skill-incident-command-center/README.md
+++ b/samples/dotnet/maf-skill-incident-command-center/README.md
@@ -18,18 +18,69 @@ Scenario: **Supply Chain Disruption Triage** with a phased capability model:
 
 ```text
 maf-skill-incident-command-center/
+├── .gitignore
+├── README.md
 ├── backend/
 │   ├── Program.cs
+│   ├── IncidentCommandCenter.Api.csproj
+│   ├── appsettings.json
+│   ├── appsettings.Development.json
 │   ├── Models/
+│   │   └── Contracts.cs
 │   ├── Services/
-│   ├── data/incidents/*.json
+│   │   ├── AgentRuntime.cs
+│   │   ├── CommunicationDraftService.cs
+│   │   ├── FileIncidentRepository.cs
+│   │   ├── FileSkillCatalogService.cs
+│   │   ├── InMemorySkillTraceStore.cs
+│   │   ├── NativeAgentSkillsContextProvider.cs
+│   │   ├── ResponseParsing.cs
+│   │   ├── SkillEventFactory.cs
+│   │   ├── SkillExecutionGuard.cs
+│   │   ├── SkillRunContextAccessor.cs
+│   │   └── [interfaces: I*.cs]
+│   ├── data/
+│   │   └── incidents/
+│   │       ├── INC-SC-1001.json
+│   │       ├── INC-SC-1002.json
+│   │       └── INC-SC-1003.json
 │   ├── skills/
 │   │   ├── incident-triage/
+│   │   │   ├── SKILL.md
+│   │   │   ├── references/
+│   │   │   │   ├── SLA_POLICY.md
+│   │   │   │   ├── ESCALATION_MATRIX.md
+│   │   │   │   └── VENDOR_CONSTRAINTS.md
+│   │   │   └── assets/
+│   │   │       ├── triage-report-template.md
+│   │   │       └── executive-brief-template.md
 │   │   └── incident-communications/
-│   └── tests/IncidentCommandCenter.Api.Tests/
-├── frontend/
-│   └── src/
-└── README.md
+│   │       ├── SKILL.md
+│   │       ├── references/
+│   │       │   └── tone-guidelines.md
+│   │       └── assets/
+│   │           ├── customer-update-template.md
+│   │           └── supplier-escalation-template.md
+│   └── tests/
+│       └── IncidentCommandCenter.Api.Tests/
+│           ├── IncidentCommandCenter.Api.Tests.csproj
+│           ├── IncidentRepositoryTests.cs
+│           ├── RuntimeValidationTests.cs
+│           ├── SkillCatalogTests.cs
+│           ├── SkillExecutionGuardTests.cs
+│           └── SkillTraceStoreTests.cs
+└── frontend/
+    ├── .env.example
+    ├── index.html
+    ├── package.json
+    ├── tsconfig.json
+    ├── vite.config.ts
+    └── src/
+        ├── api.ts
+        ├── App.tsx
+        ├── main.tsx
+        ├── styles.css
+        └── types.ts
 ```
 
 ## Skill Packages

--- a/samples/dotnet/maf-skill-incident-command-center/README.md
+++ b/samples/dotnet/maf-skill-incident-command-center/README.md
@@ -1,0 +1,149 @@
+# MAF Skill Incident Command Center
+
+A full-stack demo showing how to give agents new capabilities with **Skills** in **Microsoft Agent Framework** using the progressive disclosure pattern.
+
+Scenario: **Supply Chain Disruption Triage** with a phased capability model:
+
+1. `incident-triage` (flagship skill)
+2. `incident-communications` (advanced cooperating skill)
+
+## Stack
+
+- Backend: ASP.NET Core (`net10.0`), Microsoft Agent Framework, Azure OpenAI
+- Frontend: React + Vite + TypeScript
+- Skills: file-based skill packages loaded via `FileAgentSkillsProvider`
+
+## Project Layout
+
+```text
+maf-skill-incident-command-center/
+├── backend/
+│   ├── Program.cs
+│   ├── Models/
+│   ├── Services/
+│   ├── data/incidents/*.json
+│   ├── skills/
+│   │   ├── incident-triage/
+│   │   └── incident-communications/
+│   └── tests/IncidentCommandCenter.Api.Tests/
+├── frontend/
+│   └── src/
+└── README.md
+```
+
+## Skill Packages
+
+### `incident-triage`
+
+Purpose: classify severity, identify probable causes, and output prioritized actions.
+
+Resources:
+
+- `references/SLA_POLICY.md`
+- `references/ESCALATION_MATRIX.md`
+- `references/VENDOR_CONSTRAINTS.md`
+- `assets/triage-report-template.md`
+- `assets/executive-brief-template.md`
+
+### `incident-communications`
+
+Purpose: draft audience-specific updates from triage output.
+
+Resources:
+
+- `references/tone-guidelines.md`
+- `assets/customer-update-template.md`
+- `assets/supplier-escalation-template.md`
+
+## API Surface
+
+```http
+GET  /api/incidents
+POST /api/sessions
+POST /api/triage
+POST /api/communications/draft
+GET  /api/skills
+GET  /api/runs/{runId}/events
+```
+
+## Environment Variables
+
+Required:
+
+- `AZURE_OPENAI_ENDPOINT`
+- `AZURE_OPENAI_DEPLOYMENT_NAME`
+
+Optional:
+
+- `AZURE_OPENAI_API_KEY` (if omitted, `DefaultAzureCredential` is used)
+
+## Run Backend
+
+```powershell
+cd backend
+$env:AZURE_OPENAI_ENDPOINT="https://<your-endpoint>.openai.azure.com/"
+$env:AZURE_OPENAI_DEPLOYMENT_NAME="gpt-4o-mini"
+# Optional:
+# $env:AZURE_OPENAI_API_KEY="<your-key>"
+dotnet restore
+dotnet run
+```
+
+Backend default URL: `http://localhost:5000`
+
+## Run Frontend
+
+```powershell
+cd frontend
+copy .env.example .env
+npm install
+npm run dev
+```
+
+Frontend URL: `http://localhost:5173`
+
+## Demo Flow
+
+1. Open command center UI.
+2. Select an incident from the queue.
+3. Click **Run Triage**.
+4. Inspect skill timeline (`advertised -> loaded -> resource_read -> completed`).
+5. Open evidence drawer to see exact resources used.
+6. Trigger **Draft Stakeholder Update** to run the second skill.
+
+## Test Cases
+
+### Backend tests
+
+```powershell
+cd backend\tests\IncidentCommandCenter.Api.Tests
+dotnet test
+```
+
+Coverage includes:
+
+- Skill discovery returns both skills
+- Incident repository seed/data lookups
+- Skill event ordering
+- Missing environment variable validation
+
+### Frontend checks
+
+Manual checks:
+
+1. Incident queue loads and can select an incident.
+2. Triage call returns structured response card.
+3. Timeline shows progressive disclosure events.
+4. Evidence drawer lists resources read.
+5. Draft communication flow works with audience selector.
+
+## Manual Scenarios
+
+1. Port delay incident with SLA breach risk (`INC-SC-1001`)
+2. Supplier shortage incident with substitution pressure (`INC-SC-1002`)
+3. Customs hold incident with lower immediate risk (`INC-SC-1003`)
+
+## Notes
+
+- No mock mode is included in this sample by design.
+- Local incident JSON keeps onboarding deterministic while model calls remain real.

--- a/samples/dotnet/maf-skill-incident-command-center/backend/IncidentCommandCenter.Api.csproj
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/IncidentCommandCenter.Api.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <NoWarn>$(NoWarn);MEAI001;MAAI001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
+    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.251009.1" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-preview.251009.1" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="9.9.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="tests\**\*.cs" />
+    <None Include="skills\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="data\incidents\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Models/Contracts.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Models/Contracts.cs
@@ -1,0 +1,71 @@
+namespace IncidentCommandCenter.Api.Models;
+
+public sealed record IncidentRecord(
+    string Id,
+    string Title,
+    string Region,
+    string Vendor,
+    string Status,
+    int OpenOrders,
+    int AtRiskOrders,
+    string SlaDeadlineUtc,
+    string Summary,
+    IReadOnlyList<string> Signals,
+    IReadOnlyList<string> Constraints,
+    string LastUpdatedUtc
+);
+
+public sealed record SessionResponse(string SessionId);
+
+public sealed record ErrorResponse(string Error, string? Detail = null);
+
+public sealed record TriageRequest(
+    string SessionId,
+    string IncidentId,
+    string? UserPrompt
+);
+
+public sealed record TriageResponse(
+    string RunId,
+    string Summary,
+    string Severity,
+    IReadOnlyList<string> ProbableCauses,
+    IReadOnlyList<string> RecommendedActions,
+    IReadOnlyList<string> AtRiskOrders
+);
+
+public sealed record CommunicationDraftRequest(
+    string SessionId,
+    string IncidentId,
+    string Audience,
+    string? TriageSummary
+);
+
+public sealed record CommunicationDraftResponse(
+    string RunId,
+    string Audience,
+    string Draft
+);
+
+public sealed record SkillSummary(
+    string Name,
+    string Description,
+    IReadOnlyList<string> Resources
+);
+
+public sealed record SkillEvent(
+    string RunId,
+    string Timestamp,
+    string Stage,
+    string SkillName,
+    string? Resource,
+    string? Note
+);
+
+public sealed record TriageModel(
+    string Summary,
+    string Severity,
+    IReadOnlyList<string> ProbableCauses,
+    IReadOnlyList<string> RecommendedActions,
+    IReadOnlyList<string> AtRiskOrders
+);

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Program.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Program.cs
@@ -1,0 +1,181 @@
+using System.Text.Json;
+using IncidentCommandCenter.Api.Models;
+using IncidentCommandCenter.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+string frontendOrigin = builder.Configuration["FrontendOrigin"] ?? "http://localhost:5173";
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy => policy
+        .WithOrigins(frontendOrigin)
+        .AllowAnyHeader()
+        .AllowAnyMethod());
+});
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+});
+
+builder.Services.AddSingleton<IIncidentRepository, FileIncidentRepository>();
+builder.Services.AddSingleton<ISkillTraceStore, InMemorySkillTraceStore>();
+builder.Services.AddSingleton<ISkillCatalogService, FileAgentSkillsProvider>();
+builder.Services.AddSingleton<AgentRuntime>();
+builder.Services.AddSingleton<ICommunicationDraftService, CommunicationDraftService>();
+
+var app = builder.Build();
+
+app.UseCors();
+
+using (IServiceScope scope = app.Services.CreateScope())
+{
+    // Fail fast with a clear startup error if env vars are missing.
+    scope.ServiceProvider.GetRequiredService<AgentRuntime>().ValidateConfiguration();
+}
+
+app.MapGet("/api/incidents", (IIncidentRepository repository) =>
+{
+    return Results.Ok(repository.GetAll());
+});
+
+app.MapPost("/api/sessions", async (AgentRuntime runtime, CancellationToken cancellationToken) =>
+{
+    string sessionId = await runtime.CreateSessionAsync(cancellationToken);
+    return Results.Ok(new SessionResponse(sessionId));
+});
+
+app.MapGet("/api/skills", (ISkillCatalogService skillCatalog) =>
+{
+    return Results.Ok(skillCatalog.GetSkills());
+});
+
+app.MapGet("/api/runs/{runId}/events", (string runId, ISkillTraceStore traceStore) =>
+{
+    return Results.Ok(traceStore.GetEvents(runId));
+});
+
+app.MapPost("/api/triage", async (
+    TriageRequest request,
+    IIncidentRepository incidentRepository,
+    ISkillCatalogService skillCatalog,
+    ISkillTraceStore traceStore,
+    AgentRuntime runtime,
+    CancellationToken cancellationToken) =>
+{
+    if (!runtime.SessionExists(request.SessionId))
+    {
+        return Results.BadRequest(new ErrorResponse("invalid_session", "The provided sessionId does not exist."));
+    }
+
+    IncidentRecord? incident = incidentRepository.GetById(request.IncidentId);
+    if (incident is null)
+    {
+        return Results.NotFound(new ErrorResponse("incident_not_found", "The incidentId was not found in local data."));
+    }
+
+    string runId = $"run-{Guid.NewGuid():N}";
+
+    IReadOnlyList<SkillSummary> advertisedSkills = skillCatalog.GetSkills();
+    foreach (SkillSummary skill in advertisedSkills)
+    {
+        traceStore.AddEvent(SkillEventFactory.Create(runId, "advertised", skill.Name, null,
+            "Skill advertised to agent via context provider."));
+    }
+
+    traceStore.AddEvent(SkillEventFactory.Create(runId, "loaded", "incident-triage", null,
+        "Loaded triage instructions."));
+
+    IReadOnlyList<string> triageResources = skillCatalog.GetResources("incident-triage");
+    foreach (string resourcePath in triageResources)
+    {
+        traceStore.AddEvent(SkillEventFactory.Create(runId, "resource_read", "incident-triage", resourcePath,
+            "Loaded triage resource."));
+    }
+
+    string resourcesBundle = string.Join(
+        "\n\n",
+        triageResources.Select(path => $"### {path}\n{skillCatalog.ReadResource("incident-triage", path)}"));
+
+    string triagePrompt = $$"""
+You are triaging a supply chain incident.
+Use the provided skill resources and output STRICT JSON only with this schema:
+{
+  "summary": string,
+  "severity": "low" | "medium" | "high" | "critical",
+  "probableCauses": string[],
+  "recommendedActions": string[],
+  "atRiskOrders": string[]
+}
+
+Incident payload:
+{{JsonSerializer.Serialize(incident)}}
+
+Operator prompt:
+{{request.UserPrompt ?? "Classify severity and provide an action plan."}}
+
+Skill resources:
+{{resourcesBundle}}
+""";
+
+    string rawResponse = await runtime.RunAsync(request.SessionId, triagePrompt, cancellationToken);
+    TriageModel triage = ResponseParsing.ParseTriage(rawResponse, incident);
+
+    traceStore.AddEvent(SkillEventFactory.Create(runId, "completed", "incident-triage", null,
+        "Triage completed."));
+
+    TriageResponse response = new(
+        RunId: runId,
+        Summary: triage.Summary,
+        Severity: triage.Severity.ToLowerInvariant(),
+        ProbableCauses: triage.ProbableCauses,
+        RecommendedActions: triage.RecommendedActions,
+        AtRiskOrders: triage.AtRiskOrders
+    );
+
+    return Results.Ok(response);
+});
+
+app.MapPost("/api/communications/draft", async (
+    CommunicationDraftRequest request,
+    IIncidentRepository incidentRepository,
+    ISkillCatalogService skillCatalog,
+    ISkillTraceStore traceStore,
+    ICommunicationDraftService communicationService,
+    AgentRuntime runtime,
+    CancellationToken cancellationToken) =>
+{
+    if (!runtime.SessionExists(request.SessionId))
+    {
+        return Results.BadRequest(new ErrorResponse("invalid_session", "The provided sessionId does not exist."));
+    }
+
+    IncidentRecord? incident = incidentRepository.GetById(request.IncidentId);
+    if (incident is null)
+    {
+        return Results.NotFound(new ErrorResponse("incident_not_found", "The incidentId was not found in local data."));
+    }
+
+    string runId = $"run-{Guid.NewGuid():N}";
+
+    IReadOnlyList<SkillSummary> advertisedSkills = skillCatalog.GetSkills();
+    foreach (SkillSummary skill in advertisedSkills)
+    {
+        traceStore.AddEvent(SkillEventFactory.Create(runId, "advertised", skill.Name, null,
+            "Skill advertised to agent via context provider."));
+    }
+
+    CommunicationDraftResponse response = await communicationService.DraftAsync(
+        request.SessionId,
+        runId,
+        incident,
+        request.Audience,
+        request.TriageSummary,
+        cancellationToken);
+
+    return Results.Ok(response);
+});
+
+app.Run();
+
+public partial class Program;

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/AgentRuntime.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/AgentRuntime.cs
@@ -17,12 +17,15 @@ public sealed class AgentRuntime
     public AgentRuntime(IHostEnvironment environment)
     {
         string endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
+            ?? Environment.GetEnvironmentVariable("AOI_ENDPOINT_SWDN")
             ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
 
         string deployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")
-            ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
+            ?? Environment.GetEnvironmentVariable("AzureOpenAI__Deployment")
+            ?? "gpt-4o";
 
-        string? apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+        string? apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY")
+            ?? Environment.GetEnvironmentVariable("AOI_KEY_SWDN");
 
         AzureOpenAIClient client = string.IsNullOrWhiteSpace(apiKey)
             ? new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/AgentRuntime.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/AgentRuntime.cs
@@ -5,6 +5,7 @@ using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.ChatClient;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 using OpenAI;
 
 namespace IncidentCommandCenter.Api.Services;
@@ -12,10 +13,21 @@ namespace IncidentCommandCenter.Api.Services;
 public sealed class AgentRuntime
 {
     private readonly AIAgent _agent;
+    private readonly SkillRunContextAccessor _runContextAccessor;
+    private readonly ILogger<AgentRuntime> _logger;
     private readonly ConcurrentDictionary<string, AgentThread> _sessions = new(StringComparer.OrdinalIgnoreCase);
 
-    public AgentRuntime(IHostEnvironment environment)
+    public AgentRuntime(
+        IHostEnvironment environment,
+        ISkillCatalogService skillCatalog,
+        ISkillTraceStore traceStore,
+        SkillRunContextAccessor runContextAccessor,
+        ILogger<AgentRuntime> logger,
+        ILoggerFactory loggerFactory)
     {
+        _runContextAccessor = runContextAccessor;
+        _logger = logger;
+
         string endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
             ?? Environment.GetEnvironmentVariable("AOI_ENDPOINT_SWDN")
             ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
@@ -33,9 +45,27 @@ public sealed class AgentRuntime
 
         var chatClient = client.GetChatClient(deployment);
 
-        _agent = chatClient.CreateAIAgent(
-            instructions: "You are a supply chain disruption specialist. Use provided skill references and templates in your reasoning.",
-            tools: []);
+        ChatClientAgentOptions options = new()
+        {
+            Name = "IncidentCommandCenterAgent",
+            ChatOptions = new()
+            {
+                Instructions = "You are a supply chain disruption specialist. Use the native skills tools when domain expertise is needed.",
+            },
+            AIContextProviderFactory = _ => new NativeAgentSkillsContextProvider(
+                skillCatalog,
+                traceStore,
+                _runContextAccessor,
+                loggerFactory.CreateLogger<NativeAgentSkillsContextProvider>()),
+        };
+
+        _agent = chatClient.CreateAIAgent(options);
+
+        _logger.LogInformation(
+            "Agent runtime initialized. Environment={EnvironmentName}, Deployment={Deployment}, EndpointHost={EndpointHost}",
+            environment.EnvironmentName,
+            deployment,
+            new Uri(endpoint).Host);
 
         _ = environment;
     }
@@ -50,21 +80,38 @@ public sealed class AgentRuntime
         AgentThread session = _agent.GetNewThread();
         string sessionId = $"session-{Guid.NewGuid():N}";
         _sessions[sessionId] = session;
+        _logger.LogInformation("Created agent session {SessionId}", sessionId);
         _ = cancellationToken;
         return Task.FromResult(sessionId);
     }
 
     public bool SessionExists(string sessionId) => _sessions.ContainsKey(sessionId);
 
-    public async Task<string> RunAsync(string sessionId, string prompt, CancellationToken cancellationToken = default)
+    public async Task<string> RunAsync(
+        string sessionId,
+        string prompt,
+        string? runId = null,
+        CancellationToken cancellationToken = default)
     {
         if (!_sessions.TryGetValue(sessionId, out AgentThread? session))
         {
             throw new KeyNotFoundException($"Session '{sessionId}' does not exist.");
         }
 
+        using IDisposable scope = _runContextAccessor.Push(runId);
+        _logger.LogInformation(
+            "Starting agent run. SessionId={SessionId}, RunId={RunId}, PromptChars={PromptChars}",
+            sessionId,
+            runId ?? "<none>",
+            prompt.Length);
+
         ChatMessage userMessage = new(ChatRole.User, [new TextContent(prompt)]);
         var response = await _agent.RunAsync([userMessage], session);
+        _logger.LogInformation(
+            "Completed agent run. SessionId={SessionId}, RunId={RunId}, ResponseChars={ResponseChars}",
+            sessionId,
+            runId ?? "<none>",
+            response.Text?.Length ?? 0);
         _ = cancellationToken;
         return response.Text ?? string.Empty;
     }

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/AgentRuntime.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/AgentRuntime.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using Azure;
+using Azure.AI.OpenAI;
+using Azure.Identity;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.ChatClient;
+using Microsoft.Extensions.AI;
+using OpenAI;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class AgentRuntime
+{
+    private readonly AIAgent _agent;
+    private readonly ConcurrentDictionary<string, AgentThread> _sessions = new(StringComparer.OrdinalIgnoreCase);
+
+    public AgentRuntime(IHostEnvironment environment)
+    {
+        string endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT")
+            ?? throw new InvalidOperationException("AZURE_OPENAI_ENDPOINT is not set.");
+
+        string deployment = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME")
+            ?? throw new InvalidOperationException("AZURE_OPENAI_DEPLOYMENT_NAME is not set.");
+
+        string? apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_API_KEY");
+
+        AzureOpenAIClient client = string.IsNullOrWhiteSpace(apiKey)
+            ? new AzureOpenAIClient(new Uri(endpoint), new DefaultAzureCredential())
+            : new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(apiKey));
+
+        var chatClient = client.GetChatClient(deployment);
+
+        _agent = chatClient.CreateAIAgent(
+            instructions: "You are a supply chain disruption specialist. Use provided skill references and templates in your reasoning.",
+            tools: []);
+
+        _ = environment;
+    }
+
+    public void ValidateConfiguration()
+    {
+        // Construction already validates required runtime config.
+    }
+
+    public Task<string> CreateSessionAsync(CancellationToken cancellationToken = default)
+    {
+        AgentThread session = _agent.GetNewThread();
+        string sessionId = $"session-{Guid.NewGuid():N}";
+        _sessions[sessionId] = session;
+        _ = cancellationToken;
+        return Task.FromResult(sessionId);
+    }
+
+    public bool SessionExists(string sessionId) => _sessions.ContainsKey(sessionId);
+
+    public async Task<string> RunAsync(string sessionId, string prompt, CancellationToken cancellationToken = default)
+    {
+        if (!_sessions.TryGetValue(sessionId, out AgentThread? session))
+        {
+            throw new KeyNotFoundException($"Session '{sessionId}' does not exist.");
+        }
+
+        ChatMessage userMessage = new(ChatRole.User, [new TextContent(prompt)]);
+        var response = await _agent.RunAsync([userMessage], session);
+        _ = cancellationToken;
+        return response.Text ?? string.Empty;
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/CommunicationDraftService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/CommunicationDraftService.cs
@@ -1,0 +1,76 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class CommunicationDraftService(
+    AgentRuntime runtime,
+    ISkillCatalogService skillCatalog,
+    ISkillTraceStore traceStore) : ICommunicationDraftService
+{
+    private static readonly string[] SupportedAudiences = ["customer", "supplier", "internal-leadership"];
+
+    public async Task<CommunicationDraftResponse> DraftAsync(
+        string sessionId,
+        string runId,
+        IncidentRecord incident,
+        string audience,
+        string? triageSummary,
+        CancellationToken cancellationToken = default)
+    {
+        string normalizedAudience = NormalizeAudience(audience);
+
+        traceStore.AddEvent(SkillEventFactory.Create(runId, "loaded", "incident-communications", null,
+            $"Loaded communication skill for audience '{normalizedAudience}'."));
+
+        foreach (string resourcePath in skillCatalog.GetResources("incident-communications"))
+        {
+            traceStore.AddEvent(SkillEventFactory.Create(runId, "resource_read", "incident-communications", resourcePath,
+                "Loaded communication resource."));
+        }
+
+        string toneGuidelines = skillCatalog.ReadResource("incident-communications", "references/tone-guidelines.md");
+        string templatePath = normalizedAudience switch
+        {
+            "supplier" => "assets/supplier-escalation-template.md",
+            _ => "assets/customer-update-template.md"
+        };
+        string template = skillCatalog.ReadResource("incident-communications", templatePath);
+
+        string prompt = $$"""
+You are preparing an urgent disruption communication.
+Use this audience: {{normalizedAudience}}.
+
+Incident data:
+{{System.Text.Json.JsonSerializer.Serialize(incident)}}
+
+Optional triage summary:
+{{triageSummary ?? "No triage summary was supplied."}}
+
+Tone and rules:
+{{toneGuidelines}}
+
+Use this template and keep placeholders resolved:
+{{template}}
+
+Output only the final message body as markdown.
+""";
+
+        string draft = await runtime.RunAsync(sessionId, prompt, cancellationToken);
+
+        traceStore.AddEvent(SkillEventFactory.Create(runId, "completed", "incident-communications", null,
+            "Draft generated."));
+
+        return new CommunicationDraftResponse(runId, normalizedAudience, draft.Trim());
+    }
+
+    private static string NormalizeAudience(string audience)
+    {
+        string normalized = audience.Trim().ToLowerInvariant();
+        if (SupportedAudiences.Contains(normalized, StringComparer.Ordinal))
+        {
+            return normalized;
+        }
+
+        return "customer";
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/CommunicationDraftService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/CommunicationDraftService.cs
@@ -2,10 +2,7 @@ using IncidentCommandCenter.Api.Models;
 
 namespace IncidentCommandCenter.Api.Services;
 
-public sealed class CommunicationDraftService(
-    AgentRuntime runtime,
-    ISkillCatalogService skillCatalog,
-    ISkillTraceStore traceStore) : ICommunicationDraftService
+public sealed class CommunicationDraftService(AgentRuntime runtime) : ICommunicationDraftService
 {
     private static readonly string[] SupportedAudiences = ["customer", "supplier", "internal-leadership"];
 
@@ -19,26 +16,12 @@ public sealed class CommunicationDraftService(
     {
         string normalizedAudience = NormalizeAudience(audience);
 
-        traceStore.AddEvent(SkillEventFactory.Create(runId, "loaded", "incident-communications", null,
-            $"Loaded communication skill for audience '{normalizedAudience}'."));
-
-        foreach (string resourcePath in skillCatalog.GetResources("incident-communications"))
-        {
-            traceStore.AddEvent(SkillEventFactory.Create(runId, "resource_read", "incident-communications", resourcePath,
-                "Loaded communication resource."));
-        }
-
-        string toneGuidelines = skillCatalog.ReadResource("incident-communications", "references/tone-guidelines.md");
-        string templatePath = normalizedAudience switch
-        {
-            "supplier" => "assets/supplier-escalation-template.md",
-            _ => "assets/customer-update-template.md"
-        };
-        string template = skillCatalog.ReadResource("incident-communications", templatePath);
-
         string prompt = $$"""
 You are preparing an urgent disruption communication.
-Use this audience: {{normalizedAudience}}.
+Use native Agent Skills invocation.
+First load the `incident-communications` skill with load_skill, then read the relevant resources with read_skill_resource.
+
+Audience: {{normalizedAudience}}
 
 Incident data:
 {{System.Text.Json.JsonSerializer.Serialize(incident)}}
@@ -46,19 +29,10 @@ Incident data:
 Optional triage summary:
 {{triageSummary ?? "No triage summary was supplied."}}
 
-Tone and rules:
-{{toneGuidelines}}
-
-Use this template and keep placeholders resolved:
-{{template}}
-
 Output only the final message body as markdown.
 """;
 
-        string draft = await runtime.RunAsync(sessionId, prompt, cancellationToken);
-
-        traceStore.AddEvent(SkillEventFactory.Create(runId, "completed", "incident-communications", null,
-            "Draft generated."));
+        string draft = await runtime.RunAsync(sessionId, prompt, runId, cancellationToken);
 
         return new CommunicationDraftResponse(runId, normalizedAudience, draft.Trim());
     }

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/FileIncidentRepository.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/FileIncidentRepository.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class FileIncidentRepository : IIncidentRepository
+{
+    private readonly string _incidentDirectory;
+    private readonly Lazy<IReadOnlyList<IncidentRecord>> _cache;
+
+    public FileIncidentRepository(IHostEnvironment environment)
+    {
+        _incidentDirectory = Path.Combine(environment.ContentRootPath, "data", "incidents");
+        _cache = new Lazy<IReadOnlyList<IncidentRecord>>(LoadIncidents);
+    }
+
+    public IReadOnlyList<IncidentRecord> GetAll() => _cache.Value;
+
+    public IncidentRecord? GetById(string incidentId)
+    {
+        if (string.IsNullOrWhiteSpace(incidentId))
+        {
+            return null;
+        }
+
+        return _cache.Value.FirstOrDefault(i =>
+            string.Equals(i.Id, incidentId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private IReadOnlyList<IncidentRecord> LoadIncidents()
+    {
+        if (!Directory.Exists(_incidentDirectory))
+        {
+            return [];
+        }
+
+        JsonSerializerOptions options = new() { PropertyNameCaseInsensitive = true };
+        List<IncidentRecord> incidents = [];
+
+        foreach (string filePath in Directory.GetFiles(_incidentDirectory, "*.json", SearchOption.TopDirectoryOnly))
+        {
+            string json = File.ReadAllText(filePath);
+            IncidentRecord? incident = JsonSerializer.Deserialize<IncidentRecord>(json, options);
+            if (incident is not null)
+            {
+                incidents.Add(incident);
+            }
+        }
+
+        return incidents
+            .OrderByDescending(i => i.AtRiskOrders)
+            .ThenBy(i => i.SlaDeadlineUtc)
+            .ToArray();
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/FileSkillCatalogService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/FileSkillCatalogService.cs
@@ -5,34 +5,41 @@ namespace IncidentCommandCenter.Api.Services;
 public sealed class FileAgentSkillsProvider : ISkillCatalogService
 {
     private readonly string _skillsRoot;
-    private readonly Lazy<IReadOnlyList<SkillSummary>> _skillsCache;
+    private readonly Lazy<IReadOnlyList<SkillEntry>> _entriesCache;
 
     public FileAgentSkillsProvider(IHostEnvironment environment)
     {
         _skillsRoot = Path.Combine(environment.ContentRootPath, "skills");
-        _skillsCache = new Lazy<IReadOnlyList<SkillSummary>>(LoadSkills);
+        _entriesCache = new Lazy<IReadOnlyList<SkillEntry>>(LoadSkillEntries);
     }
 
-    public IReadOnlyList<SkillSummary> GetSkills() => _skillsCache.Value;
+    public IReadOnlyList<SkillSummary> GetSkills() => _entriesCache.Value
+        .Select(entry => new SkillSummary(entry.Name, entry.Description, entry.Resources))
+        .OrderBy(skill => skill.Name, StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    public string ResolveSkillName(string skillName)
+    {
+        SkillEntry entry = ResolveEntry(skillName);
+        return entry.FolderName;
+    }
+
+    public string ReadSkillDefinition(string skillName)
+    {
+        SkillEntry entry = ResolveEntry(skillName);
+        return File.ReadAllText(entry.SkillDefinitionPath);
+    }
 
     public IReadOnlyList<string> GetResources(string skillName)
     {
-        string folder = Path.Combine(_skillsRoot, skillName);
-        if (!Directory.Exists(folder))
-        {
-            return [];
-        }
-
-        return Directory.GetFiles(folder, "*", SearchOption.AllDirectories)
-            .Where(file => !file.EndsWith("SKILL.md", StringComparison.OrdinalIgnoreCase))
-            .Select(file => Path.GetRelativePath(folder, file).Replace('\\', '/'))
-            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        SkillEntry entry = ResolveEntry(skillName);
+        return entry.Resources;
     }
 
     public string ReadResource(string skillName, string resourcePath)
     {
-        string filePath = Path.Combine(_skillsRoot, skillName, resourcePath.Replace('/', Path.DirectorySeparatorChar));
+        SkillEntry entry = ResolveEntry(skillName);
+        string filePath = Path.Combine(_skillsRoot, entry.FolderName, resourcePath.Replace('/', Path.DirectorySeparatorChar));
         if (!File.Exists(filePath))
         {
             throw new FileNotFoundException($"Resource '{resourcePath}' was not found for skill '{skillName}'.", filePath);
@@ -41,17 +48,38 @@ public sealed class FileAgentSkillsProvider : ISkillCatalogService
         return File.ReadAllText(filePath);
     }
 
-    private IReadOnlyList<SkillSummary> LoadSkills()
+    private SkillEntry ResolveEntry(string skillName)
+    {
+        if (string.IsNullOrWhiteSpace(skillName))
+        {
+            throw new ArgumentException("Skill name is required.", nameof(skillName));
+        }
+
+        string normalized = skillName.Trim();
+
+        SkillEntry? entry = _entriesCache.Value.FirstOrDefault(candidate =>
+            string.Equals(candidate.FolderName, normalized, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(candidate.Name, normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null)
+        {
+            throw new InvalidOperationException($"Skill '{skillName}' was not found.");
+        }
+
+        return entry;
+    }
+
+    private IReadOnlyList<SkillEntry> LoadSkillEntries()
     {
         if (!Directory.Exists(_skillsRoot))
         {
             return [];
         }
 
-        List<SkillSummary> skills = [];
+        List<SkillEntry> skills = [];
         foreach (string skillFolder in Directory.GetDirectories(_skillsRoot))
         {
-            string skillName = Path.GetFileName(skillFolder);
+            string folderName = Path.GetFileName(skillFolder);
             string skillDefinitionPath = Path.Combine(skillFolder, "SKILL.md");
             if (!File.Exists(skillDefinitionPath))
             {
@@ -59,17 +87,25 @@ public sealed class FileAgentSkillsProvider : ISkillCatalogService
             }
 
             string skillText = File.ReadAllText(skillDefinitionPath);
-            string parsedName = ParseFrontMatterValue(skillText, "name") ?? skillName;
+            string parsedName = ParseFrontMatterValue(skillText, "name") ?? folderName;
             string description = ParseFrontMatterValue(skillText, "description")
                 ?? "No description found in SKILL.md";
 
-            IReadOnlyList<string> resources = GetResources(skillName);
-            skills.Add(new SkillSummary(parsedName, description, resources));
+            IReadOnlyList<string> resources = Directory.GetFiles(skillFolder, "*", SearchOption.AllDirectories)
+                .Where(file => !file.EndsWith("SKILL.md", StringComparison.OrdinalIgnoreCase))
+                .Select(file => Path.GetRelativePath(skillFolder, file).Replace('\\', '/'))
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            skills.Add(new SkillEntry(
+                FolderName: folderName,
+                Name: parsedName,
+                Description: description,
+                SkillDefinitionPath: skillDefinitionPath,
+                Resources: resources));
         }
 
-        return skills
-            .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+        return skills;
     }
 
     private static string? ParseFrontMatterValue(string markdown, string key)
@@ -105,4 +141,11 @@ public sealed class FileAgentSkillsProvider : ISkillCatalogService
 
         return null;
     }
+
+    private sealed record SkillEntry(
+        string FolderName,
+        string Name,
+        string Description,
+        string SkillDefinitionPath,
+        IReadOnlyList<string> Resources);
 }

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/FileSkillCatalogService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/FileSkillCatalogService.cs
@@ -1,0 +1,108 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class FileAgentSkillsProvider : ISkillCatalogService
+{
+    private readonly string _skillsRoot;
+    private readonly Lazy<IReadOnlyList<SkillSummary>> _skillsCache;
+
+    public FileAgentSkillsProvider(IHostEnvironment environment)
+    {
+        _skillsRoot = Path.Combine(environment.ContentRootPath, "skills");
+        _skillsCache = new Lazy<IReadOnlyList<SkillSummary>>(LoadSkills);
+    }
+
+    public IReadOnlyList<SkillSummary> GetSkills() => _skillsCache.Value;
+
+    public IReadOnlyList<string> GetResources(string skillName)
+    {
+        string folder = Path.Combine(_skillsRoot, skillName);
+        if (!Directory.Exists(folder))
+        {
+            return [];
+        }
+
+        return Directory.GetFiles(folder, "*", SearchOption.AllDirectories)
+            .Where(file => !file.EndsWith("SKILL.md", StringComparison.OrdinalIgnoreCase))
+            .Select(file => Path.GetRelativePath(folder, file).Replace('\\', '/'))
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public string ReadResource(string skillName, string resourcePath)
+    {
+        string filePath = Path.Combine(_skillsRoot, skillName, resourcePath.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"Resource '{resourcePath}' was not found for skill '{skillName}'.", filePath);
+        }
+
+        return File.ReadAllText(filePath);
+    }
+
+    private IReadOnlyList<SkillSummary> LoadSkills()
+    {
+        if (!Directory.Exists(_skillsRoot))
+        {
+            return [];
+        }
+
+        List<SkillSummary> skills = [];
+        foreach (string skillFolder in Directory.GetDirectories(_skillsRoot))
+        {
+            string skillName = Path.GetFileName(skillFolder);
+            string skillDefinitionPath = Path.Combine(skillFolder, "SKILL.md");
+            if (!File.Exists(skillDefinitionPath))
+            {
+                continue;
+            }
+
+            string skillText = File.ReadAllText(skillDefinitionPath);
+            string parsedName = ParseFrontMatterValue(skillText, "name") ?? skillName;
+            string description = ParseFrontMatterValue(skillText, "description")
+                ?? "No description found in SKILL.md";
+
+            IReadOnlyList<string> resources = GetResources(skillName);
+            skills.Add(new SkillSummary(parsedName, description, resources));
+        }
+
+        return skills
+            .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string? ParseFrontMatterValue(string markdown, string key)
+    {
+        string[] lines = markdown.Replace("\r", string.Empty).Split('\n');
+        if (lines.Length == 0 || lines[0] != "---")
+        {
+            return null;
+        }
+
+        for (int i = 1; i < lines.Length; i++)
+        {
+            string line = lines[i];
+            if (line == "---")
+            {
+                break;
+            }
+
+            int colonIndex = line.IndexOf(':');
+            if (colonIndex <= 0)
+            {
+                continue;
+            }
+
+            string currentKey = line[..colonIndex].Trim();
+            if (!string.Equals(currentKey, key, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return line[(colonIndex + 1)..].Trim().Trim('"');
+        }
+
+        return null;
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/ICommunicationDraftService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/ICommunicationDraftService.cs
@@ -1,0 +1,14 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public interface ICommunicationDraftService
+{
+    Task<CommunicationDraftResponse> DraftAsync(
+        string sessionId,
+        string runId,
+        IncidentRecord incident,
+        string audience,
+        string? triageSummary,
+        CancellationToken cancellationToken = default);
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/IIncidentRepository.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/IIncidentRepository.cs
@@ -1,0 +1,9 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public interface IIncidentRepository
+{
+    IReadOnlyList<IncidentRecord> GetAll();
+    IncidentRecord? GetById(string incidentId);
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/ISkillCatalogService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/ISkillCatalogService.cs
@@ -5,6 +5,8 @@ namespace IncidentCommandCenter.Api.Services;
 public interface ISkillCatalogService
 {
     IReadOnlyList<SkillSummary> GetSkills();
+    string ResolveSkillName(string skillName);
+    string ReadSkillDefinition(string skillName);
     IReadOnlyList<string> GetResources(string skillName);
     string ReadResource(string skillName, string resourcePath);
 }

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/ISkillCatalogService.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/ISkillCatalogService.cs
@@ -1,0 +1,10 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public interface ISkillCatalogService
+{
+    IReadOnlyList<SkillSummary> GetSkills();
+    IReadOnlyList<string> GetResources(string skillName);
+    string ReadResource(string skillName, string resourcePath);
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/ISkillTraceStore.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/ISkillTraceStore.cs
@@ -1,0 +1,9 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public interface ISkillTraceStore
+{
+    void AddEvent(SkillEvent skillEvent);
+    IReadOnlyList<SkillEvent> GetEvents(string runId);
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/InMemorySkillTraceStore.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/InMemorySkillTraceStore.cs
@@ -1,0 +1,33 @@
+using System.Collections.Concurrent;
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class InMemorySkillTraceStore : ISkillTraceStore
+{
+    private readonly ConcurrentDictionary<string, List<SkillEvent>> _events = new(StringComparer.OrdinalIgnoreCase);
+
+    public void AddEvent(SkillEvent skillEvent)
+    {
+        List<SkillEvent> runEvents = _events.GetOrAdd(skillEvent.RunId, _ => []);
+        lock (runEvents)
+        {
+            runEvents.Add(skillEvent);
+        }
+    }
+
+    public IReadOnlyList<SkillEvent> GetEvents(string runId)
+    {
+        if (!_events.TryGetValue(runId, out List<SkillEvent>? runEvents))
+        {
+            return [];
+        }
+
+        lock (runEvents)
+        {
+            return runEvents
+                .OrderBy(e => e.Timestamp, StringComparer.Ordinal)
+                .ToArray();
+        }
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/NativeAgentSkillsContextProvider.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/NativeAgentSkillsContextProvider.cs
@@ -1,0 +1,107 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class NativeAgentSkillsContextProvider(
+    ISkillCatalogService skillCatalog,
+    ISkillTraceStore traceStore,
+    SkillRunContextAccessor runContextAccessor,
+    ILogger<NativeAgentSkillsContextProvider> logger) : AIContextProvider
+{
+    private readonly AITool _loadSkillTool = AIFunctionFactory.Create((string skillName) =>
+        LoadSkill(skillCatalog, traceStore, runContextAccessor, logger, skillName));
+
+    private readonly AITool _readSkillResourceTool = AIFunctionFactory.Create((string skillName, string resourcePath) =>
+        ReadSkillResource(skillCatalog, traceStore, runContextAccessor, logger, skillName, resourcePath));
+
+    public override ValueTask<AIContext> InvokingAsync(InvokingContext context, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<Models.SkillSummary> skills = skillCatalog.GetSkills();
+        string advertisedSkills = string.Join("\n", skills.Select(skill => $"- {skill.Name}: {skill.Description}"));
+
+        AIContext aiContext = new()
+        {
+            Instructions = $$"""
+You have access to native Skill tools. Use them when the task requires domain-specific policy, templates, or references.
+
+Available skills:
+{{advertisedSkills}}
+
+Tool usage protocol:
+1. Call load_skill(skillName) to fetch full SKILL.md instructions.
+2. Call read_skill_resource(skillName, resourcePath) for references/assets linked by the skill.
+3. Follow skill rules before final answer.
+""",
+            Tools = [_loadSkillTool, _readSkillResourceTool],
+        };
+
+        logger.LogInformation(
+            "Injected native skill tools into AI context. SkillCount={SkillCount}, RunId={RunId}",
+            skills.Count,
+            runContextAccessor.CurrentRunId ?? "<none>");
+
+        _ = context;
+        _ = cancellationToken;
+        return ValueTask.FromResult(aiContext);
+    }
+
+    public override ValueTask InvokedAsync(InvokedContext context, CancellationToken cancellationToken = default)
+    {
+        _ = context;
+        _ = cancellationToken;
+        return ValueTask.CompletedTask;
+    }
+
+    private static string LoadSkill(
+        ISkillCatalogService skillCatalog,
+        ISkillTraceStore traceStore,
+        SkillRunContextAccessor runContextAccessor,
+        ILogger<NativeAgentSkillsContextProvider> logger,
+        string skillName)
+    {
+        string resolvedSkill = skillCatalog.ResolveSkillName(skillName);
+        string content = skillCatalog.ReadSkillDefinition(resolvedSkill);
+        logger.LogInformation(
+            "Native tool call: load_skill. Requested={RequestedSkill}, Resolved={ResolvedSkill}, RunId={RunId}",
+            skillName,
+            resolvedSkill,
+            runContextAccessor.CurrentRunId ?? "<none>");
+
+        string? runId = runContextAccessor.CurrentRunId;
+        if (!string.IsNullOrWhiteSpace(runId))
+        {
+            traceStore.AddEvent(SkillEventFactory.Create(runId, "loaded", resolvedSkill, null,
+                "Skill loaded through native load_skill tool."));
+        }
+
+        return content;
+    }
+
+    private static string ReadSkillResource(
+        ISkillCatalogService skillCatalog,
+        ISkillTraceStore traceStore,
+        SkillRunContextAccessor runContextAccessor,
+        ILogger<NativeAgentSkillsContextProvider> logger,
+        string skillName,
+        string resourcePath)
+    {
+        string resolvedSkill = skillCatalog.ResolveSkillName(skillName);
+        string content = skillCatalog.ReadResource(resolvedSkill, resourcePath);
+        logger.LogInformation(
+            "Native tool call: read_skill_resource. Skill={ResolvedSkill}, Resource={ResourcePath}, RunId={RunId}",
+            resolvedSkill,
+            resourcePath,
+            runContextAccessor.CurrentRunId ?? "<none>");
+
+        string? runId = runContextAccessor.CurrentRunId;
+        if (!string.IsNullOrWhiteSpace(runId))
+        {
+            traceStore.AddEvent(SkillEventFactory.Create(runId, "resource_read", resolvedSkill, resourcePath,
+                "Resource loaded through native read_skill_resource tool."));
+        }
+
+        return content;
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/ResponseParsing.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/ResponseParsing.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public static class ResponseParsing
+{
+    public static TriageModel ParseTriage(string responseText, IncidentRecord incident)
+    {
+        string jsonCandidate = TryExtractJsonObject(responseText) ?? responseText;
+
+        try
+        {
+            JsonSerializerOptions options = new() { PropertyNameCaseInsensitive = true };
+            TriageModel? parsed = JsonSerializer.Deserialize<TriageModel>(jsonCandidate, options);
+            if (parsed is not null
+                && !string.IsNullOrWhiteSpace(parsed.Summary)
+                && !string.IsNullOrWhiteSpace(parsed.Severity))
+            {
+                return parsed;
+            }
+        }
+        catch
+        {
+            // Fall through to heuristic output.
+        }
+
+        string severity = incident.AtRiskOrders >= 20 ? "critical"
+            : incident.AtRiskOrders >= 10 ? "high"
+            : incident.AtRiskOrders >= 5 ? "medium"
+            : "low";
+
+        return new TriageModel(
+            Summary: responseText.Trim(),
+            Severity: severity,
+            ProbableCauses: incident.Signals,
+            RecommendedActions:
+            [
+                "Escalate to the logistics lead within 15 minutes.",
+                "Trigger alternate vendor availability check.",
+                "Send proactive customer ETA notice."
+            ],
+            AtRiskOrders: [
+                $"{incident.Region}-ORD-4021",
+                $"{incident.Region}-ORD-7745"
+            ]
+        );
+    }
+
+    private static string? TryExtractJsonObject(string text)
+    {
+        int start = text.IndexOf('{');
+        int end = text.LastIndexOf('}');
+        if (start < 0 || end <= start)
+        {
+            return null;
+        }
+
+        return text[start..(end + 1)];
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/SkillEventFactory.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/SkillEventFactory.cs
@@ -1,0 +1,23 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public static class SkillEventFactory
+{
+    public static SkillEvent Create(
+        string runId,
+        string stage,
+        string skillName,
+        string? resource,
+        string? note)
+    {
+        return new SkillEvent(
+            RunId: runId,
+            Timestamp: DateTimeOffset.UtcNow.ToString("O"),
+            Stage: stage,
+            SkillName: skillName,
+            Resource: resource,
+            Note: note
+        );
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/SkillExecutionGuard.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/SkillExecutionGuard.cs
@@ -1,0 +1,18 @@
+using IncidentCommandCenter.Api.Models;
+
+namespace IncidentCommandCenter.Api.Services;
+
+public static class SkillExecutionGuard
+{
+    public static bool HasLoadedSkill(IReadOnlyList<SkillEvent> events, string expectedSkillName)
+    {
+        if (string.IsNullOrWhiteSpace(expectedSkillName))
+        {
+            return false;
+        }
+
+        return events.Any(e =>
+            string.Equals(e.Stage, "loaded", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(e.SkillName, expectedSkillName, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/Services/SkillRunContextAccessor.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/Services/SkillRunContextAccessor.cs
@@ -1,0 +1,31 @@
+namespace IncidentCommandCenter.Api.Services;
+
+public sealed class SkillRunContextAccessor
+{
+    private readonly AsyncLocal<string?> _runId = new();
+
+    public string? CurrentRunId => _runId.Value;
+
+    public IDisposable Push(string? runId)
+    {
+        string? previous = _runId.Value;
+        _runId.Value = runId;
+        return new Scope(this, previous);
+    }
+
+    private sealed class Scope(SkillRunContextAccessor accessor, string? previous) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            accessor._runId.Value = previous;
+            _disposed = true;
+        }
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/appsettings.Development.json
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/appsettings.json
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "FrontendOrigin": "http://localhost:5173",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/data/incidents/INC-SC-1001.json
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/data/incidents/INC-SC-1001.json
@@ -1,0 +1,21 @@
+{
+  "id": "INC-SC-1001",
+  "title": "Port congestion delaying refrigerated shipments",
+  "region": "APAC",
+  "vendor": "Blue Harbor Logistics",
+  "status": "active",
+  "openOrders": 42,
+  "atRiskOrders": 17,
+  "slaDeadlineUtc": "2026-02-22T08:00:00Z",
+  "summary": "A weather-related port backlog has delayed outbound refrigerated containers by 36 hours.",
+  "signals": [
+    "Port queue times increased from 5h to 19h",
+    "Cold-chain telemetry reports 2 temperature variance alerts",
+    "Carrier reduced reefer slot allocation by 18%"
+  ],
+  "constraints": [
+    "Perishable inventory expires within 72 hours",
+    "No premium reroute approved above 12% cost uplift"
+  ],
+  "lastUpdatedUtc": "2026-02-21T02:15:00Z"
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/data/incidents/INC-SC-1002.json
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/data/incidents/INC-SC-1002.json
@@ -1,0 +1,21 @@
+{
+  "id": "INC-SC-1002",
+  "title": "Supplier resin shortage impacting packaging",
+  "region": "EMEA",
+  "vendor": "Nordic Polymer Works",
+  "status": "active",
+  "openOrders": 28,
+  "atRiskOrders": 9,
+  "slaDeadlineUtc": "2026-02-24T16:30:00Z",
+  "summary": "Primary packaging material supplier reported a 10-day resin shortage after an unplanned plant shutdown.",
+  "signals": [
+    "Supplier lead times moved from 4 days to 13 days",
+    "Secondary supplier stock availability at 42%",
+    "Warehouse packaging buffer dropped below safety threshold"
+  ],
+  "constraints": [
+    "Labeling compliance requires approved material spec",
+    "Backorder tolerance capped at 15% for strategic accounts"
+  ],
+  "lastUpdatedUtc": "2026-02-21T05:40:00Z"
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/data/incidents/INC-SC-1003.json
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/data/incidents/INC-SC-1003.json
@@ -1,0 +1,21 @@
+{
+  "id": "INC-SC-1003",
+  "title": "Cross-region customs hold on critical components",
+  "region": "NA",
+  "vendor": "Vertex Components",
+  "status": "watch",
+  "openOrders": 19,
+  "atRiskOrders": 4,
+  "slaDeadlineUtc": "2026-02-27T12:00:00Z",
+  "summary": "A documentation mismatch triggered customs review for a shipment of high-priority electronic components.",
+  "signals": [
+    "Customs broker reported HS code mismatch",
+    "Two production lines move to constrained mode within 48 hours",
+    "Alternative inventory available for 3 days"
+  ],
+  "constraints": [
+    "Regulatory paperwork must be corrected before release",
+    "Air-freight exception requires director approval"
+  ],
+  "lastUpdatedUtc": "2026-02-21T07:05:00Z"
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/SKILL.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: incident-communications
+description: Convert triage outputs into audience-specific disruption communications for customers, suppliers, and internal leadership.
+metadata:
+  author: operations-communications
+  version: "1.0"
+---
+
+# Incident Communications Skill
+
+Use this skill after triage is complete to produce clear, honest, and action-oriented updates.
+
+## Output Expectations
+
+- Keep updates direct and specific.
+- Avoid speculative timelines.
+- Include the next checkpoint time.
+- Be explicit about what actions are already in flight.
+
+## Resources
+
+- [references/tone-guidelines.md](references/tone-guidelines.md)
+- [assets/customer-update-template.md](assets/customer-update-template.md)
+- [assets/supplier-escalation-template.md](assets/supplier-escalation-template.md)

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/assets/customer-update-template.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/assets/customer-update-template.md
@@ -1,0 +1,21 @@
+# Customer Update Template
+
+Subject: Service Update on Your Shipment Timeline
+
+Hello {{CustomerName}},
+
+We are currently managing a supply chain disruption affecting part of your shipment pipeline.
+
+What happened:
+- {{WhatHappened}}
+
+Current impact:
+- {{Impact}}
+
+What we are doing:
+- {{MitigationActions}}
+
+Next update:
+- {{NextUpdateTime}}
+
+Thank you for your patience while we work through this.

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/assets/supplier-escalation-template.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/assets/supplier-escalation-template.md
@@ -1,0 +1,18 @@
+# Supplier Escalation Template
+
+Subject: Urgent Escalation: Supply Disruption Impact and Required Action
+
+Hello {{SupplierName}},
+
+We are escalating an active disruption linked to {{DependencyArea}}.
+
+Current impact:
+- {{ImpactSummary}}
+
+Action required from your team:
+- {{RequestedAction}}
+
+Decision deadline:
+- {{DecisionDeadline}}
+
+Please confirm owner and ETA for action completion.

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/references/tone-guidelines.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-communications/references/tone-guidelines.md
@@ -1,0 +1,22 @@
+# Tone Guidelines for Disruption Communications
+
+## General Rules
+
+- Lead with facts, then impact, then next steps.
+- Avoid blaming language.
+- Use active voice and short sentences.
+- Never over-promise on ETA.
+
+## Audience Guidance
+
+### Customer
+- Emphasize impact transparency and mitigation actions.
+- Provide the next update timestamp.
+
+### Supplier
+- Be explicit on dependency impact and required action.
+- Include decision deadline.
+
+### Internal Leadership
+- Focus on business risk, options, and decisions needed.
+- Include confidence level and fallback path.

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/SKILL.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: incident-triage
+description: Classify supply-chain disruption severity, identify likely root causes, and generate prioritized mitigation actions for operations teams.
+metadata:
+  author: operations-intelligence
+  version: "1.0"
+---
+
+# Incident Triage Skill
+
+Use this skill when the operator needs severity classification, risk framing, immediate actions, and escalation guidance for shipment disruptions.
+
+## Triage Workflow
+
+1. Assess urgency using SLA risk, at-risk orders, and business impact.
+2. Map active disruption signals to probable causes.
+3. Prioritize actions in the first 15 minutes, first 2 hours, and same-day horizon.
+4. Prepare a concise executive brief using the supplied templates.
+
+## Severity Rules
+
+- `critical`: severe SLA breach probability with high-volume or high-value customer impact.
+- `high`: measurable disruption with likely customer impact if not addressed quickly.
+- `medium`: manageable disruption with clear containment path.
+- `low`: limited impact and no immediate escalation required.
+
+## Required Outputs
+
+- Severity decision with reasoning.
+- Top 3 probable causes.
+- Action plan ordered by urgency.
+- At-risk order clusters.
+- Recommendation on escalation tier.
+
+## Resources
+
+- [references/SLA_POLICY.md](references/SLA_POLICY.md)
+- [references/ESCALATION_MATRIX.md](references/ESCALATION_MATRIX.md)
+- [references/VENDOR_CONSTRAINTS.md](references/VENDOR_CONSTRAINTS.md)
+- [assets/triage-report-template.md](assets/triage-report-template.md)
+- [assets/executive-brief-template.md](assets/executive-brief-template.md)

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/assets/executive-brief-template.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/assets/executive-brief-template.md
@@ -1,0 +1,18 @@
+# Executive Brief Template
+
+## Situation
+Provide a two-sentence summary with business impact and timeline risk.
+
+## Risk Position
+- SLA exposure:
+- Revenue/penalty exposure:
+- Customer impact:
+
+## Decision Requests
+- Decision 1:
+- Decision 2:
+
+## Recovery Plan
+- Mitigation in progress:
+- Next milestone:
+- Confidence level:

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/assets/triage-report-template.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/assets/triage-report-template.md
@@ -1,0 +1,35 @@
+# Triage Report Template
+
+## Incident Summary
+- Incident ID:
+- Region:
+- Vendor:
+- Current status:
+
+## Severity Decision
+- Severity:
+- Rationale:
+
+## Probable Causes
+1.
+2.
+3.
+
+## Immediate Actions
+### First 15 Minutes
+- 
+
+### First 2 Hours
+- 
+
+### Same Day
+- 
+
+## At-Risk Orders
+- Count:
+- Segments:
+
+## Escalation Decision
+- Tier:
+- Owner:
+- Next checkpoint:

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/references/ESCALATION_MATRIX.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/references/ESCALATION_MATRIX.md
@@ -1,0 +1,22 @@
+# Escalation Matrix
+
+## Escalation Tiers
+
+1. **Tier 1 (Ops Lead)**
+   - Trigger: medium risk, no active customer churn indicator.
+   - SLA for acknowledgement: 15 minutes.
+
+2. **Tier 2 (Regional Director)**
+   - Trigger: high risk, potential SLA penalties, strategic account exposure.
+   - SLA for acknowledgement: 10 minutes.
+
+3. **Tier 3 (Executive Command)**
+   - Trigger: critical risk, multi-region impact, safety/compliance risk, major contractual penalties.
+   - SLA for acknowledgement: 5 minutes.
+
+## Escalation Inputs
+
+- At-risk order count and % of open orders.
+- Inventory shelf-life or production line stoppage horizon.
+- Contractual penalty probability.
+- Recovery path confidence.

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/references/SLA_POLICY.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/references/SLA_POLICY.md
@@ -1,0 +1,23 @@
+# SLA Policy (Supply Chain)
+
+## Priority Targets
+
+| Service Tier | On-Time SLA | Breach Threshold | Financial Penalty Trigger |
+|---|---|---|---|
+| Platinum | 98.5% | < 97% | Immediate |
+| Gold | 97% | < 95% | Within 24 hours |
+| Standard | 95% | < 93% | Weekly review |
+
+## Breach Risk Guidelines
+
+- If projected delay exceeds 12 hours for Platinum, classify as at least `high`.
+- If delay exceeds 24 hours with perishable goods, classify as `critical` unless mitigated.
+- If at-risk orders exceed 25% of open orders, raise one severity tier.
+
+## Communication Expectations
+
+- Customer-facing communication must be issued within 30 minutes for `critical` and 60 minutes for `high` incidents.
+- Internal leadership update cadence:
+  - `critical`: every 30 minutes
+  - `high`: every 2 hours
+  - `medium`: twice per day

--- a/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/references/VENDOR_CONSTRAINTS.md
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/skills/incident-triage/references/VENDOR_CONSTRAINTS.md
@@ -1,0 +1,19 @@
+# Vendor Constraints & Recovery Rules
+
+## Constraint Types
+
+- **Capacity constraints**: supplier cannot increase throughput for 3-10 days.
+- **Transport constraints**: carrier schedule or lane capacity reduced.
+- **Compliance constraints**: substitutions require approval and documentation.
+
+## Recovery Guidelines
+
+- Prefer substitution suppliers for non-regulated components.
+- For regulated packaging or food/pharma logistics, substitutions require quality sign-off.
+- Premium freight usage above 12% budget uplift needs director approval.
+- For perishable goods, prioritize spoilage prevention over margin preservation.
+
+## Risk Notes
+
+- Cross-border disruptions can amplify delay variance by 1.8x.
+- Multi-vendor handoff points increase failure probability during active disruptions.

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/IncidentCommandCenter.Api.Tests.csproj
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/IncidentCommandCenter.Api.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\IncidentCommandCenter.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/IncidentRepositoryTests.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/IncidentRepositoryTests.cs
@@ -1,0 +1,65 @@
+using IncidentCommandCenter.Api.Services;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace IncidentCommandCenter.Api.Tests;
+
+public sealed class IncidentRepositoryTests
+{
+    [Fact]
+    public void GetById_ReturnsNull_WhenIncidentDoesNotExist()
+    {
+        var env = new TestHostEnvironment
+        {
+            ContentRootPath = ResolveBackendRoot(),
+        };
+
+        IIncidentRepository repository = new FileIncidentRepository(env);
+
+        var incident = repository.GetById("INC-UNKNOWN");
+
+        Assert.Null(incident);
+    }
+
+    [Fact]
+    public void GetAll_ReturnsSeededIncidents()
+    {
+        var env = new TestHostEnvironment
+        {
+            ContentRootPath = ResolveBackendRoot(),
+        };
+
+        IIncidentRepository repository = new FileIncidentRepository(env);
+
+        var incidents = repository.GetAll();
+
+        Assert.True(incidents.Count >= 3);
+        Assert.Contains(incidents, i => i.Id == "INC-SC-1001");
+    }
+
+    private static string ResolveBackendRoot()
+    {
+        string current = AppContext.BaseDirectory;
+        DirectoryInfo? dir = new DirectoryInfo(current);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "IncidentCommandCenter.Api.csproj")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not resolve backend project root.");
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "IncidentCommandCenter.Api.Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/RuntimeValidationTests.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/RuntimeValidationTests.cs
@@ -1,0 +1,60 @@
+using IncidentCommandCenter.Api.Services;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace IncidentCommandCenter.Api.Tests;
+
+public sealed class RuntimeValidationTests
+{
+    [Fact]
+    public void AgentRuntime_Throws_WhenRequiredEnvironmentVariablesAreMissing()
+    {
+        string? endpointBefore = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+        string? deploymentBefore = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("AZURE_OPENAI_ENDPOINT", null);
+            Environment.SetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME", null);
+
+            var env = new TestHostEnvironment
+            {
+                ContentRootPath = ResolveBackendRoot(),
+            };
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => new AgentRuntime(env));
+            Assert.Contains("AZURE_OPENAI_ENDPOINT", ex.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AZURE_OPENAI_ENDPOINT", endpointBefore);
+            Environment.SetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT_NAME", deploymentBefore);
+        }
+    }
+
+    private static string ResolveBackendRoot()
+    {
+        string current = AppContext.BaseDirectory;
+        DirectoryInfo? dir = new DirectoryInfo(current);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "IncidentCommandCenter.Api.csproj")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not resolve backend project root.");
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "IncidentCommandCenter.Api.Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillCatalogTests.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillCatalogTests.cs
@@ -1,0 +1,65 @@
+using IncidentCommandCenter.Api.Services;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace IncidentCommandCenter.Api.Tests;
+
+public sealed class SkillCatalogTests
+{
+    [Fact]
+    public void GetSkills_ReturnsExpectedSkillNames()
+    {
+        var env = new TestHostEnvironment
+        {
+            ContentRootPath = ResolveBackendRoot(),
+        };
+
+        ISkillCatalogService catalog = new FileAgentSkillsProvider(env);
+
+        var skills = catalog.GetSkills();
+
+        Assert.Contains(skills, s => s.Name == "incident-triage");
+        Assert.Contains(skills, s => s.Name == "incident-communications");
+    }
+
+    [Fact]
+    public void GetResources_ReturnsExpectedReferences()
+    {
+        var env = new TestHostEnvironment
+        {
+            ContentRootPath = ResolveBackendRoot(),
+        };
+
+        ISkillCatalogService catalog = new FileAgentSkillsProvider(env);
+        var resources = catalog.GetResources("incident-triage");
+
+        Assert.Contains("references/SLA_POLICY.md", resources);
+        Assert.Contains("assets/triage-report-template.md", resources);
+    }
+
+    private static string ResolveBackendRoot()
+    {
+        string current = AppContext.BaseDirectory;
+        DirectoryInfo? dir = new DirectoryInfo(current);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "IncidentCommandCenter.Api.csproj")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("Could not resolve backend project root.");
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+        public string ApplicationName { get; set; } = "IncidentCommandCenter.Api.Tests";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillCatalogTests.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillCatalogTests.cs
@@ -38,6 +38,23 @@ public sealed class SkillCatalogTests
         Assert.Contains("assets/triage-report-template.md", resources);
     }
 
+    [Fact]
+    public void ReadSkillDefinition_ReturnsSkillMarkdown()
+    {
+        var env = new TestHostEnvironment
+        {
+            ContentRootPath = ResolveBackendRoot(),
+        };
+
+        ISkillCatalogService catalog = new FileAgentSkillsProvider(env);
+
+        string resolved = catalog.ResolveSkillName("incident-triage");
+        string skillMarkdown = catalog.ReadSkillDefinition(resolved);
+
+        Assert.Equal("incident-triage", resolved);
+        Assert.Contains("Incident Triage Skill", skillMarkdown);
+    }
+
     private static string ResolveBackendRoot()
     {
         string current = AppContext.BaseDirectory;

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillExecutionGuardTests.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillExecutionGuardTests.cs
@@ -1,0 +1,38 @@
+using IncidentCommandCenter.Api.Models;
+using IncidentCommandCenter.Api.Services;
+using Xunit;
+
+namespace IncidentCommandCenter.Api.Tests;
+
+public sealed class SkillExecutionGuardTests
+{
+    [Fact]
+    public void HasLoadedSkill_ReturnsTrue_WhenExpectedSkillWasLoaded()
+    {
+        IReadOnlyList<SkillEvent> events =
+        [
+            new("run-1", "2026-02-21T10:00:00.0000000Z", "advertised", "incident-triage", null, null),
+            new("run-1", "2026-02-21T10:00:01.0000000Z", "loaded", "incident-triage", null, null),
+            new("run-1", "2026-02-21T10:00:02.0000000Z", "completed", "incident-triage", null, null),
+        ];
+
+        bool result = SkillExecutionGuard.HasLoadedSkill(events, "incident-triage");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasLoadedSkill_ReturnsFalse_WhenSkillWasNotLoaded()
+    {
+        IReadOnlyList<SkillEvent> events =
+        [
+            new("run-1", "2026-02-21T10:00:00.0000000Z", "advertised", "incident-triage", null, null),
+            new("run-1", "2026-02-21T10:00:01.0000000Z", "resource_read", "incident-triage", "references/SLA_POLICY.md", null),
+            new("run-1", "2026-02-21T10:00:02.0000000Z", "completed", "incident-triage", null, null),
+        ];
+
+        bool result = SkillExecutionGuard.HasLoadedSkill(events, "incident-triage");
+
+        Assert.False(result);
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillTraceStoreTests.cs
+++ b/samples/dotnet/maf-skill-incident-command-center/backend/tests/IncidentCommandCenter.Api.Tests/SkillTraceStoreTests.cs
@@ -1,0 +1,25 @@
+using IncidentCommandCenter.Api.Models;
+using IncidentCommandCenter.Api.Services;
+using Xunit;
+
+namespace IncidentCommandCenter.Api.Tests;
+
+public sealed class SkillTraceStoreTests
+{
+    [Fact]
+    public void Events_AreReturnedInTimestampOrder()
+    {
+        ISkillTraceStore store = new InMemorySkillTraceStore();
+        string runId = "run-123";
+
+        store.AddEvent(new SkillEvent(runId, "2026-02-21T10:00:02.0000000Z", "completed", "incident-triage", null, null));
+        store.AddEvent(new SkillEvent(runId, "2026-02-21T10:00:00.0000000Z", "advertised", "incident-triage", null, null));
+        store.AddEvent(new SkillEvent(runId, "2026-02-21T10:00:01.0000000Z", "loaded", "incident-triage", null, null));
+
+        var events = store.GetEvents(runId);
+
+        Assert.Equal("advertised", events[0].Stage);
+        Assert.Equal("loaded", events[1].Stage);
+        Assert.Equal("completed", events[2].Stage);
+    }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/.env.example
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:5000

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/index.html
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Incident Command Center</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/package.json
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "maf-skill-incident-command-center-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.2",
+    "vite": "^6.3.5"
+  }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/src/App.tsx
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/src/App.tsx
@@ -45,7 +45,7 @@ export default function App() {
   const [incidents, setIncidents] = useState<Incident[]>([]);
   const [skills, setSkills] = useState<SkillSummary[]>([]);
   const [selectedIncidentId, setSelectedIncidentId] = useState<string>("");
-  const [triagePrompt, setTriagePrompt] = useState<string>("Prioritize actions for the first two hours and explain escalation.");
+  const [triagePrompt, setTriagePrompt] = useState<string>("Prioritise actions for the first two hours and explain escalation.");
   const [triage, setTriage] = useState<TriageResponse | null>(null);
   const [timelineEvents, setTimelineEvents] = useState<SkillEvent[]>([]);
   const [audience, setAudience] = useState<string>("customer");

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/src/App.tsx
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/src/App.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  createSession,
+  draftCommunication,
+  getIncidents,
+  getRunEvents,
+  getSkills,
+  runTriage,
+} from "./api";
+import type { Incident, SkillEvent, SkillSummary, TriageResponse } from "./types";
+
+const STAGE_LABELS: Record<string, string> = {
+  advertised: "Advertised",
+  loaded: "Loaded",
+  resource_read: "Resource Read",
+  completed: "Completed",
+};
+
+export default function App() {
+  const [sessionId, setSessionId] = useState<string>("");
+  const [incidents, setIncidents] = useState<Incident[]>([]);
+  const [skills, setSkills] = useState<SkillSummary[]>([]);
+  const [selectedIncidentId, setSelectedIncidentId] = useState<string>("");
+  const [triagePrompt, setTriagePrompt] = useState<string>("Prioritize actions for the first two hours and explain escalation.");
+  const [triage, setTriage] = useState<TriageResponse | null>(null);
+  const [timelineEvents, setTimelineEvents] = useState<SkillEvent[]>([]);
+  const [audience, setAudience] = useState<string>("customer");
+  const [draft, setDraft] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [isTriageLoading, setIsTriageLoading] = useState(false);
+  const [isDraftLoading, setIsDraftLoading] = useState(false);
+
+  useEffect(() => {
+    async function bootstrap() {
+      try {
+        const [session, incidentData, skillData] = await Promise.all([
+          createSession(),
+          getIncidents(),
+          getSkills(),
+        ]);
+
+        setSessionId(session.sessionId);
+        setIncidents(incidentData);
+        setSkills(skillData);
+
+        if (incidentData.length > 0) {
+          setSelectedIncidentId(incidentData[0].id);
+        }
+      } catch (bootstrapError) {
+        setError((bootstrapError as Error).message);
+      }
+    }
+
+    bootstrap();
+  }, []);
+
+  const selectedIncident = useMemo(
+    () => incidents.find((incident) => incident.id === selectedIncidentId) ?? null,
+    [incidents, selectedIncidentId]
+  );
+
+  const metrics = useMemo(() => {
+    const openIncidents = incidents.filter((incident) => incident.status !== "resolved").length;
+    const highSeverityRisk = incidents.filter((incident) => incident.atRiskOrders >= 10).length;
+    const totalAtRiskOrders = incidents.reduce((sum, incident) => sum + incident.atRiskOrders, 0);
+
+    return {
+      openIncidents,
+      highSeverityRisk,
+      totalAtRiskOrders,
+    };
+  }, [incidents]);
+
+  const evidenceResources = useMemo(() => {
+    return Array.from(new Set(timelineEvents.map((event) => event.resource).filter(Boolean) as string[]));
+  }, [timelineEvents]);
+
+  async function refreshEvents(runId: string) {
+    const events = await getRunEvents(runId);
+    setTimelineEvents(events);
+  }
+
+  async function handleRunTriage() {
+    if (!sessionId || !selectedIncident) {
+      return;
+    }
+
+    setError("");
+    setDraft("");
+    setIsTriageLoading(true);
+
+    try {
+      const response = await runTriage({
+        sessionId,
+        incidentId: selectedIncident.id,
+        userPrompt: triagePrompt,
+      });
+
+      setTriage(response);
+      await refreshEvents(response.runId);
+    } catch (triageError) {
+      setError((triageError as Error).message);
+    } finally {
+      setIsTriageLoading(false);
+    }
+  }
+
+  async function handleDraftCommunication() {
+    if (!sessionId || !selectedIncident || !triage) {
+      return;
+    }
+
+    setError("");
+    setIsDraftLoading(true);
+
+    try {
+      const response = await draftCommunication({
+        sessionId,
+        incidentId: selectedIncident.id,
+        audience,
+        triageSummary: triage.summary,
+      });
+
+      setDraft(response.draft);
+      await refreshEvents(response.runId);
+    } catch (draftError) {
+      setError((draftError as Error).message);
+    } finally {
+      setIsDraftLoading(false);
+    }
+  }
+
+  return (
+    <div className="app-shell">
+      <header className="topbar fade-in-up">
+        <div>
+          <p className="eyebrow">Microsoft Agent Framework + Skills</p>
+          <h1>Supply Chain Incident Command Center</h1>
+          <p className="subtitle">
+            Progressive disclosure in action: skills advertise, load, and read evidence before producing triage and communication output.
+          </p>
+        </div>
+        <div className="session-chip">Session: {sessionId || "starting..."}</div>
+      </header>
+
+      <section className="kpi-strip fade-in-up delay-1">
+        <article className="kpi-card">
+          <span>Open incidents</span>
+          <strong>{metrics.openIncidents}</strong>
+        </article>
+        <article className="kpi-card">
+          <span>High-risk incidents</span>
+          <strong>{metrics.highSeverityRisk}</strong>
+        </article>
+        <article className="kpi-card">
+          <span>At-risk orders</span>
+          <strong>{metrics.totalAtRiskOrders}</strong>
+        </article>
+      </section>
+
+      {error ? <div className="error-banner">{error}</div> : null}
+
+      <main className="layout-grid">
+        <aside className="panel queue-panel fade-in-up delay-2">
+          <div className="panel-header">
+            <h2>Incident Queue</h2>
+          </div>
+          <ul className="incident-list">
+            {incidents.map((incident) => (
+              <li key={incident.id}>
+                <button
+                  className={`incident-item ${incident.id === selectedIncidentId ? "active" : ""}`}
+                  onClick={() => setSelectedIncidentId(incident.id)}
+                  type="button"
+                >
+                  <div className="incident-top">
+                    <span>{incident.id}</span>
+                    <span className="status-pill">{incident.status}</span>
+                  </div>
+                  <h3>{incident.title}</h3>
+                  <p>{incident.region} • {incident.vendor}</p>
+                  <small>{incident.atRiskOrders} at-risk orders</small>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+
+        <section className="panel workspace-panel fade-in-up delay-3">
+          <div className="panel-header">
+            <h2>Triage Workspace</h2>
+          </div>
+
+          {selectedIncident ? (
+            <>
+              <article className="incident-context">
+                <h3>{selectedIncident.title}</h3>
+                <p>{selectedIncident.summary}</p>
+                <div className="chips">
+                  <span>{selectedIncident.region}</span>
+                  <span>{selectedIncident.vendor}</span>
+                  <span>SLA: {new Date(selectedIncident.slaDeadlineUtc).toLocaleString()}</span>
+                </div>
+              </article>
+
+              <label className="field-label" htmlFor="triage-prompt">
+                Operator directive
+              </label>
+              <textarea
+                id="triage-prompt"
+                value={triagePrompt}
+                onChange={(event) => setTriagePrompt(event.target.value)}
+                rows={4}
+              />
+
+              <div className="actions">
+                <button onClick={handleRunTriage} disabled={isTriageLoading} type="button">
+                  {isTriageLoading ? "Running triage..." : "Run Triage"}
+                </button>
+              </div>
+
+              {triage ? (
+                <article className="triage-card fade-in-up">
+                  <div className="triage-head">
+                    <h3>Triage Result</h3>
+                    <span className={`severity ${triage.severity}`}>{triage.severity}</span>
+                  </div>
+                  <p>{triage.summary}</p>
+
+                  <div className="triage-grid">
+                    <div>
+                      <h4>Probable causes</h4>
+                      <ul>
+                        {triage.probableCauses.map((cause) => (
+                          <li key={cause}>{cause}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <h4>Recommended actions</h4>
+                      <ul>
+                        {triage.recommendedActions.map((action) => (
+                          <li key={action}>{action}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <h4>At-risk order clusters</h4>
+                      <ul>
+                        {triage.atRiskOrders.map((order) => (
+                          <li key={order}>{order}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+
+                  <div className="draft-zone">
+                    <h4>Phase 2: Stakeholder Draft</h4>
+                    <div className="draft-controls">
+                      <select value={audience} onChange={(event) => setAudience(event.target.value)}>
+                        <option value="customer">Customer</option>
+                        <option value="supplier">Supplier</option>
+                        <option value="internal-leadership">Internal leadership</option>
+                      </select>
+                      <button onClick={handleDraftCommunication} disabled={isDraftLoading} type="button">
+                        {isDraftLoading ? "Drafting..." : "Draft Stakeholder Update"}
+                      </button>
+                    </div>
+                    {draft ? <pre className="draft-output">{draft}</pre> : null}
+                  </div>
+                </article>
+              ) : null}
+            </>
+          ) : (
+            <p className="empty-state">No incident selected.</p>
+          )}
+        </section>
+
+        <aside className="panel timeline-panel fade-in-up delay-4">
+          <div className="panel-header">
+            <h2>Skill Timeline</h2>
+          </div>
+
+          <ul className="timeline-list">
+            {timelineEvents.length === 0 ? (
+              <li className="timeline-empty">Run triage to see progressive disclosure events.</li>
+            ) : (
+              timelineEvents.map((event, index) => (
+                <li key={`${event.timestamp}-${index}`} className={`timeline-event stage-${event.stage}`}>
+                  <span>{STAGE_LABELS[event.stage] ?? event.stage}</span>
+                  <strong>{event.skillName}</strong>
+                  {event.resource ? <code>{event.resource}</code> : null}
+                  {event.note ? <p>{event.note}</p> : null}
+                  <small>{new Date(event.timestamp).toLocaleTimeString()}</small>
+                </li>
+              ))
+            )}
+          </ul>
+
+          <details className="evidence-drawer" open>
+            <summary>Evidence Drawer ({evidenceResources.length})</summary>
+            <ul>
+              {evidenceResources.length === 0 ? (
+                <li>No resources loaded yet.</li>
+              ) : (
+                evidenceResources.map((resource) => <li key={resource}>{resource}</li>)
+              )}
+            </ul>
+          </details>
+
+          <section className="skill-catalog">
+            <h3>Advertised Skills</h3>
+            {skills.map((skill) => (
+              <article key={skill.name} className="skill-card">
+                <h4>{skill.name}</h4>
+                <p>{skill.description}</p>
+              </article>
+            ))}
+          </section>
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/src/api.ts
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/src/api.ts
@@ -1,0 +1,70 @@
+import type {
+  CommunicationDraftRequest,
+  CommunicationDraftResponse,
+  Incident,
+  SessionResponse,
+  SkillEvent,
+  SkillSummary,
+  TriageRequest,
+  TriageResponse,
+} from "./types";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:5000";
+
+async function callApi<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      const body = await response.json();
+      if (body?.detail) {
+        message = body.detail;
+      } else if (body?.error) {
+        message = body.error;
+      }
+    } catch {
+      // Ignore parse failure and keep status text.
+    }
+
+    throw new Error(message);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function createSession(): Promise<SessionResponse> {
+  return callApi<SessionResponse>("/api/sessions", { method: "POST" });
+}
+
+export function getIncidents(): Promise<Incident[]> {
+  return callApi<Incident[]>("/api/incidents");
+}
+
+export function getSkills(): Promise<SkillSummary[]> {
+  return callApi<SkillSummary[]>("/api/skills");
+}
+
+export function runTriage(payload: TriageRequest): Promise<TriageResponse> {
+  return callApi<TriageResponse>("/api/triage", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function draftCommunication(payload: CommunicationDraftRequest): Promise<CommunicationDraftResponse> {
+  return callApi<CommunicationDraftResponse>("/api/communications/draft", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getRunEvents(runId: string): Promise<SkillEvent[]> {
+  return callApi<SkillEvent[]>(`/api/runs/${runId}/events`);
+}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/src/main.tsx
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/src/styles.css
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/src/styles.css
@@ -1,0 +1,510 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
+
+:root {
+  --bg-0: #07111f;
+  --bg-1: #0f1f35;
+  --bg-2: #152e49;
+  --panel: rgba(9, 18, 31, 0.72);
+  --panel-border: rgba(96, 220, 255, 0.22);
+  --text: #e7f5ff;
+  --muted: #9cc4dc;
+  --accent: #4fe2ff;
+  --accent-strong: #00b9ff;
+  --amber: #ffb955;
+  --danger: #ff5f7b;
+  --success: #52d8a1;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "IBM Plex Sans", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(60rem 45rem at 12% -10%, rgba(79, 226, 255, 0.22), transparent 58%),
+    radial-gradient(55rem 45rem at 86% 8%, rgba(255, 185, 85, 0.18), transparent 55%),
+    linear-gradient(180deg, var(--bg-2), var(--bg-0));
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.02) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.02) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.app-shell {
+  max-width: 1480px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: "Space Grotesk", sans-serif;
+}
+
+.topbar h1 {
+  margin: 0.4rem 0;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  max-width: 70ch;
+}
+
+.session-chip {
+  border: 1px solid var(--panel-border);
+  background: rgba(8, 17, 30, 0.8);
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.82rem;
+  color: var(--accent);
+}
+
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin-top: 1.2rem;
+}
+
+.kpi-card {
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  backdrop-filter: blur(10px);
+}
+
+.kpi-card span {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.kpi-card strong {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 1.45rem;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr) 360px;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.panel {
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  background: var(--panel);
+  backdrop-filter: blur(10px);
+  padding: 1rem;
+  min-height: 520px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.error-banner {
+  margin-top: 1rem;
+  border: 1px solid rgba(255, 95, 123, 0.4);
+  background: rgba(255, 95, 123, 0.12);
+  color: #ffd6df;
+  border-radius: 12px;
+  padding: 0.75rem 0.9rem;
+}
+
+.incident-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.8rem 0 0;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.incident-item {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(8, 16, 27, 0.85);
+  border-radius: 12px;
+  color: var(--text);
+  text-align: left;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.incident-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(79, 226, 255, 0.45);
+}
+
+.incident-item.active {
+  border-color: var(--accent-strong);
+  background: rgba(8, 31, 45, 0.9);
+}
+
+.incident-top {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.77rem;
+  color: var(--muted);
+}
+
+.status-pill {
+  color: var(--amber);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.incident-item h3 {
+  margin: 0.4rem 0;
+  font-size: 0.95rem;
+}
+
+.incident-item p,
+.incident-item small {
+  margin: 0;
+  color: var(--muted);
+}
+
+.incident-context {
+  border: 1px solid rgba(79, 226, 255, 0.22);
+  border-radius: 12px;
+  padding: 0.85rem;
+  margin: 0.8rem 0;
+  background: rgba(9, 26, 39, 0.65);
+}
+
+.incident-context h3 {
+  margin: 0;
+}
+
+.incident-context p {
+  margin: 0.4rem 0;
+  color: var(--muted);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.chips span {
+  border: 1px solid rgba(79, 226, 255, 0.25);
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.77rem;
+  color: #b9ebff;
+}
+
+.field-label {
+  display: block;
+  margin: 0.3rem 0;
+  font-weight: 600;
+}
+
+textarea,
+select {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(8, 16, 27, 0.9);
+  color: var(--text);
+  padding: 0.7rem;
+  font-family: inherit;
+}
+
+textarea:focus,
+select:focus {
+  outline: 1px solid var(--accent-strong);
+}
+
+.actions,
+.draft-controls {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.6rem;
+}
+
+button {
+  border: 0;
+  border-radius: 10px;
+  padding: 0.62rem 0.95rem;
+  cursor: pointer;
+  font-weight: 600;
+  background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+  color: #022232;
+  transition: filter 160ms ease, transform 160ms ease;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.triage-card {
+  margin-top: 1rem;
+  border: 1px solid rgba(79, 226, 255, 0.2);
+  border-radius: 12px;
+  padding: 0.9rem;
+  background: rgba(9, 17, 30, 0.88);
+}
+
+.triage-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.severity {
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-size: 0.74rem;
+  border-radius: 999px;
+  padding: 0.22rem 0.6rem;
+  border: 1px solid transparent;
+}
+
+.severity.low {
+  color: var(--success);
+  border-color: rgba(82, 216, 161, 0.45);
+}
+
+.severity.medium {
+  color: var(--amber);
+  border-color: rgba(255, 185, 85, 0.45);
+}
+
+.severity.high,
+.severity.critical {
+  color: #ffc2cd;
+  border-color: rgba(255, 95, 123, 0.45);
+}
+
+.triage-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.8rem;
+  margin-top: 0.7rem;
+}
+
+.triage-grid h4 {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.triage-grid ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1rem;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.draft-zone {
+  margin-top: 0.85rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  padding-top: 0.8rem;
+}
+
+.draft-output {
+  margin-top: 0.75rem;
+  white-space: pre-wrap;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(6, 12, 20, 0.9);
+  border-radius: 10px;
+  padding: 0.75rem;
+  color: #d8f4ff;
+}
+
+.timeline-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+  display: grid;
+  gap: 0.6rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.timeline-event {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-left-width: 4px;
+  border-radius: 10px;
+  padding: 0.55rem 0.7rem;
+  background: rgba(7, 13, 23, 0.85);
+}
+
+.timeline-event span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.timeline-event strong {
+  display: block;
+  margin-top: 0.2rem;
+}
+
+.timeline-event code {
+  display: block;
+  margin-top: 0.2rem;
+  color: #9be9ff;
+  word-break: break-all;
+}
+
+.timeline-event p,
+.timeline-event small {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+}
+
+.stage-advertised {
+  border-left-color: #4fe2ff;
+}
+
+.stage-loaded {
+  border-left-color: #52d8a1;
+}
+
+.stage-resource_read {
+  border-left-color: #ffb955;
+}
+
+.stage-completed {
+  border-left-color: #ff5f7b;
+}
+
+.timeline-empty {
+  color: var(--muted);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 10px;
+  padding: 0.8rem;
+}
+
+.evidence-drawer {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  padding: 0.65rem;
+  background: rgba(7, 15, 24, 0.76);
+}
+
+.evidence-drawer summary {
+  cursor: pointer;
+  color: #bcefff;
+  font-weight: 600;
+}
+
+.evidence-drawer ul {
+  margin: 0.55rem 0 0;
+  padding-left: 1rem;
+  color: var(--muted);
+}
+
+.skill-catalog {
+  margin-top: 0.9rem;
+}
+
+.skill-catalog h3 {
+  margin: 0 0 0.55rem;
+  font-size: 0.95rem;
+}
+
+.skill-card {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  padding: 0.55rem;
+  margin-bottom: 0.55rem;
+  background: rgba(8, 14, 25, 0.86);
+}
+
+.skill-card h4 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.skill-card p {
+  margin: 0.28rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.fade-in-up {
+  animation: fade-in-up 420ms cubic-bezier(0.23, 1, 0.32, 1) both;
+}
+
+.delay-1 {
+  animation-delay: 70ms;
+}
+
+.delay-2 {
+  animation-delay: 120ms;
+}
+
+.delay-3 {
+  animation-delay: 170ms;
+}
+
+.delay-4 {
+  animation-delay: 220ms;
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1200px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .triage-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/src/types.ts
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/src/types.ts
@@ -1,0 +1,61 @@
+export type Incident = {
+  id: string;
+  title: string;
+  region: string;
+  vendor: string;
+  status: string;
+  openOrders: number;
+  atRiskOrders: number;
+  slaDeadlineUtc: string;
+  summary: string;
+  signals: string[];
+  constraints: string[];
+  lastUpdatedUtc: string;
+};
+
+export type SessionResponse = {
+  sessionId: string;
+};
+
+export type TriageRequest = {
+  sessionId: string;
+  incidentId: string;
+  userPrompt?: string;
+};
+
+export type TriageResponse = {
+  runId: string;
+  summary: string;
+  severity: "low" | "medium" | "high" | "critical";
+  probableCauses: string[];
+  recommendedActions: string[];
+  atRiskOrders: string[];
+};
+
+export type CommunicationDraftRequest = {
+  sessionId: string;
+  incidentId: string;
+  audience: string;
+  triageSummary?: string;
+};
+
+export type CommunicationDraftResponse = {
+  runId: string;
+  audience: string;
+  draft: string;
+};
+
+export type SkillSummary = {
+  name: string;
+  description: string;
+  resources: string[];
+};
+
+export type SkillEvent = {
+  runId: string;
+  timestamp: string;
+  stage: "advertised" | "loaded" | "resource_read" | "completed";
+  skillName: string;
+  resource?: string;
+  note?: string;
+};

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/tsconfig.json
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/tsconfig.tsbuildinfo
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/app.tsx","./src/api.ts","./src/main.tsx","./src/types.ts"],"version":"5.9.3"}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/tsconfig.tsbuildinfo
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/app.tsx","./src/api.ts","./src/main.tsx","./src/types.ts"],"version":"5.9.3"}

--- a/samples/dotnet/maf-skill-incident-command-center/frontend/vite.config.ts
+++ b/samples/dotnet/maf-skill-incident-command-center/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Description

This PR adds a new full-stack demo showcasing **Skills** in **Microsoft Agent Framework** using the progressive disclosure pattern.

### What's included

**Scenario:** Supply Chain Disruption Triage with phased capability model
- `incident-triage` skill - classify severity, identify causes, output prioritized actions
- `incident-communications` skill - draft audience-specific updates from triage output

**Stack:**
- Backend: ASP.NET Core (net10.0), Microsoft Agent Framework, Azure OpenAI
- Frontend: React + Vite + TypeScript
- Native skill invocation with context provider tools

### Key Features

- File-based skill packages with progressive disclosure
- Native skill tools: `load_skill` and `read_skill_resource`
- Full API surface for incident triage and communications
- Comprehensive test coverage
- Detailed logging for skill lifecycle tracing

### Changes in this PR

- Added complete backend implementation with services and models
- Added React frontend with incident queue, triage UI, and evidence drawer
- Added two skill packages with reference documents and templates
- Added test suite with 5 test classes
- Updated README with detailed project structure and setup instructions
- Fixed spelling to use British English in default prompt

## Testing

Backend tests can be run with:
```powershell
cd backend\tests\IncidentCommandCenter.Api.Tests
dotnet test
```

Demo flow validated with manual scenarios for port delays, supplier shortages, and customs holds.